### PR TITLE
Confluence/remove grpc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-examples/.ipynb_checkpoints/
-examples/geckodriver.log
 docs/build
 __pycache__
+build
+carta.egg-info

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "carta-scripting-grpc"]
-	path = carta-scripting-grpc
-	url = https://github.com/CARTAvis/carta-scripting-grpc

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 carta-python
 ------------
 
-This is a prototype of a scripting interface which uses a generic gRPC service in the CARTA backend as a proxy to call actions on the CARTA frontend.
+This is a prototype of a scripting interface which uses a generic HTTP interface in the CARTA backend as a proxy to call actions on the CARTA frontend.
 
 The protocol buffer definitions and associated files are in a submodule which has to be loaded. Either clone the repository with `--recursive`, or load the submodule afterwards:
 
     git submodule update --init
 
-This package is not yet published on PyPi, but can be installed from the local repository directory with `pip`. Ensure that you're using a Python 3 installation and its corresponding `pip`, either using a `virtualenv` or the appropriate system executable, which may be called `pip3`. Python dependencies (such as `grpcio` and `grpcio-tools`) should be installed automatically:
+This package is not yet published on PyPi, but can be installed from the local repository directory with `pip`. Ensure that you're using a Python 3 installation and its corresponding `pip`, either using a `virtualenv` or the appropriate system executable, which may be called `pip3`. Required dependencies (the `requests` library) should be installed automatically:
 
     pip install .
 

--- a/carta/backend.py
+++ b/carta/backend.py
@@ -9,6 +9,7 @@ import signal
 
 from .token import BackendToken
 
+
 class Backend:
     """Helper class for managing a CARTA backend process.
 

--- a/carta/backend.py
+++ b/carta/backend.py
@@ -11,9 +11,9 @@ from .token import BackendToken
 
 class Backend:
     """Helper class for managing a CARTA backend process.
-    
+
     You should not need to instantiate this directly; it is created on demand by a :obj:`carta.browser.Browser` object.
-    
+
     Parameters
     ----------
     params : iterable
@@ -24,7 +24,7 @@ class Backend:
         If this is set, an attempt will be made to start the backend over ``ssh`` on this host.
     token : :obj:`carta.token.BackendToken`
         If this is set, this will be used as the security token and no attempt will be made to parse the token from the backend output.
-    
+
     Attributes
     ----------
     proc : :obj:`subprocess.Popen`
@@ -39,16 +39,16 @@ class Backend:
         All output of the backend process, split into lines, terminated by newline characters.
     errors : list of strings
         Error output of the backend process, split into lines, terminated by newline characters.
-        
+
     Returns
     -------
     :obj:`carta.backend.Backend`
-        A backend object with a process which has not been started. 
-    
+        A backend object with a process which has not been started.
+
     """
     FRONTEND_URL = re.compile(r"CARTA is accessible at (http://.*?:\d+/\?token=(.*))")
     FRONTEND_URL_NO_AUTH = re.compile(r"CARTA is accessible at (http://(.*?):\d+.*)")
-    
+
     def __init__(self, params, executable_path="carta", remote_host=None, token=None):
         self.proc = None
         self.frontend_url = None
@@ -56,53 +56,53 @@ class Backend:
         self.debug_no_auth = ("--debug_no_auth" in params)
         self.output = []
         self.errors = []
-        
+
         ssh_cmd = ("ssh", "-tt", remote_host) if remote_host is not None else tuple()
         self.cmd = tuple(str(p) for p in (*ssh_cmd, executable_path, *params))
-            
+
     def start(self):
         """Start the backend process.
-        
+
         This method creates the subprocess object and parses the backend host and the frontend URL from the process output.
         """
         # TODO currently we log everything to stdout, but maybe we shouldn't
         self.proc = subprocess.Popen(self.cmd, stdout=subprocess.PIPE, cwd=pathlib.Path.home(), preexec_fn=os.setpgrp)
         os.set_blocking(self.proc.stdout.fileno(), False)
-        
+
         time.sleep(1)
-        
+
         while True:
             line = self.proc.stdout.readline()
             if not line:
                 break
             line = line.decode()
-            
+
             self.output.append(line)
             if "[error]" in line or "[critical]" in line:
                 self.errors.append(line)
-        
+
         if self.proc.poll() is not None:
             return False
-        
+
         frontend_url_re = self.FRONTEND_URL if not self.debug_no_auth else self.FRONTEND_URL_NO_AUTH
-        
+
         for line in self.output:
             m = frontend_url_re.search(line)
             if m:
                 self.frontend_url, token_string = m.groups()
                 break
-        
+
         if self.token is None and not self.debug_no_auth:
             self.token = BackendToken(token_string)
-        
+
         return True
-    
+
     def stop(self):
         """Stop the backend process.
-        
+
         This method terminates the backend process if it exists and is running.
         """
-        
+
         pgrp = os.getpgid(self.proc.pid)
         os.killpg(pgrp, signal.SIGINT)
         self.proc.wait()

--- a/carta/backend.py
+++ b/carta/backend.py
@@ -1,0 +1,108 @@
+"""This module provides a backend object which corresponds to a CARTA backend process. It is used by the wrapper to manage a local or remote backend process directly when creating a headless browser session."""
+
+import time
+import re
+import os
+import subprocess
+import pathlib
+import signal
+
+from .token import BackendToken
+
+class Backend:
+    """Helper class for managing a CARTA backend process.
+    
+    You should not need to instantiate this directly; it is created on demand by a :obj:`carta.browser.Browser` object.
+    
+    Parameters
+    ----------
+    params : iterable
+        Parameters to pass to the CARTA backend process.
+    executable_path : string
+        The path to the backend executable. Default: ``"carta"``.
+    remote_host : string
+        If this is set, an attempt will be made to start the backend over ``ssh`` on this host.
+    token : :obj:`carta.token.BackendToken`
+        If this is set, this will be used as the security token and no attempt will be made to parse the token from the backend output.
+    
+    Attributes
+    ----------
+    proc : :obj:`subprocess.Popen`
+        The backend subprocess object. Set by the :obj:`carta.backend.Backend.start` method.
+    frontend_url : string
+        The URL of the running frontend, parsed from the output of the backend process. Set by the :obj:`carta.backend.Backend.start` method.
+    token : :obj:`carta.token.BackendToken`
+        The security token of the running backend, either parsed from the output of the backend process and set by the :obj:`carta.backend.Backend.start` method, or overridden with a parameter.
+    debug_no_auth : boolean
+        If this is set, the backend will accept HTTP connections with no authentication token. This is provided for debugging purposes only and should not be used under normal circumstances. This value is automatically detected from the provided backend parameters.
+    output : list of strings
+        All output of the backend process, split into lines, terminated by newline characters.
+    errors : list of strings
+        Error output of the backend process, split into lines, terminated by newline characters.
+        
+    Returns
+    -------
+    :obj:`carta.backend.Backend`
+        A backend object with a process which has not been started. 
+    
+    """
+    FRONTEND_URL = re.compile(r"CARTA is accessible at (http://.*?:\d+/\?token=(.*))")
+    FRONTEND_URL_NO_AUTH = re.compile(r"CARTA is accessible at (http://(.*?):\d+.*)")
+    
+    def __init__(self, params, executable_path="carta", remote_host=None, token=None):
+        self.proc = None
+        self.frontend_url = None
+        self.token = token
+        self.debug_no_auth = ("--debug_no_auth" in params)
+        self.output = []
+        self.errors = []
+        
+        ssh_cmd = ("ssh", "-tt", remote_host) if remote_host is not None else tuple()
+        self.cmd = tuple(str(p) for p in (*ssh_cmd, executable_path, *params))
+            
+    def start(self):
+        """Start the backend process.
+        
+        This method creates the subprocess object and parses the backend host and the frontend URL from the process output.
+        """
+        # TODO currently we log everything to stdout, but maybe we shouldn't
+        self.proc = subprocess.Popen(self.cmd, stdout=subprocess.PIPE, cwd=pathlib.Path.home(), preexec_fn=os.setpgrp)
+        os.set_blocking(self.proc.stdout.fileno(), False)
+        
+        time.sleep(1)
+        
+        while True:
+            line = self.proc.stdout.readline()
+            if not line:
+                break
+            line = line.decode()
+            
+            self.output.append(line)
+            if "[error]" in line or "[critical]" in line:
+                self.errors.append(line)
+        
+        if self.proc.poll() is not None:
+            return False
+        
+        frontend_url_re = self.FRONTEND_URL if not self.debug_no_auth else self.FRONTEND_URL_NO_AUTH
+        
+        for line in self.output:
+            m = frontend_url_re.search(line)
+            if m:
+                self.frontend_url, token_string = m.groups()
+                break
+        
+        if self.token is None and not self.debug_no_auth:
+            self.token = BackendToken(token_string)
+        
+        return True
+    
+    def stop(self):
+        """Stop the backend process.
+        
+        This method terminates the backend process if it exists and is running.
+        """
+        
+        pgrp = os.getpgid(self.proc.pid)
+        os.killpg(pgrp, signal.SIGINT)
+        self.proc.wait()

--- a/carta/browser.py
+++ b/carta/browser.py
@@ -115,7 +115,7 @@ class Backend:
         os.killpg(pgrp, signal.SIGINT)
         self.proc.wait()
 
-
+# TODO split backend to separate file
 class Browser:
     """The top-level browser class.
     
@@ -250,22 +250,30 @@ class Browser:
         self.driver.quit()
 
 
-class ChromeHeadless(Browser):
-    """Chrome or Chromium running headless, using the SwiftShader renderer for WebGL."""
-    def __init__(self):
-        chrome_options = Options()
-        chrome_options.add_argument("--use-gl=swiftshader")
-        chrome_options.add_argument("--headless")
-        super().__init__(webdriver.Chrome, options=chrome_options)
-
-
 class Chrome(Browser):
-    """Chrome or Chromium, no special options."""
-    def __init__(self):
-        super().__init__(webdriver.Chrome)
+    """Chrome or Chromium, optionally headless.
 
+    Parameters
+    ----------
+    headless : boolean, optional
+        Run the browser headless (this is the default).
+    browser_path : string, optional
+        A path to a custom chrome or chromium executable.
+    driver_path : string, optional
+        A path to a custom chromedriver executable.
+    """
+    def __init__(self, headless=True, browser_path=None, driver_path=None):
+        options = Options()
+        if headless:
+            options.add_argument("--headless")
+        if browser_path:
+            options.binary_location = browser_path
 
-class Firefox(Browser):
-    """Firefox, no special options."""
-    def __init__(self):
-        super().__init__(webdriver.Firefox)
+        kwargs = {
+            "options": options,
+        }
+
+        if driver_path:
+            kwargs["executable_path"] = driver_path
+
+        super().__init__(webdriver.Chrome, **kwargs)

--- a/carta/browser.py
+++ b/carta/browser.py
@@ -12,7 +12,7 @@ from selenium.webdriver.chrome.options import Options
 from selenium.common.exceptions import NoSuchElementException
 
 from .util import CartaBadSession
-from .client import Session
+from .session import Session
 from .protocol import Protocol
 from .token import BackendToken
 
@@ -139,7 +139,7 @@ class Browser:
     def new_session_from_url(self, frontend_url, token=None, backend=None, timeout=10, debug_no_auth=False):
         """Create a new session by connecting to an existing backend.
         
-        You can use :obj:`carta.client.Session.create`, which wraps this method.
+        You can use :obj:`carta.session.Session.create`, which wraps this method.
         
         Parameters
         ----------
@@ -156,7 +156,7 @@ class Browser:
             
         Returns
         -------
-        :obj:`carta.client.Session`
+        :obj:`carta.session.Session`
             A session object connected to a new frontend session running in this browser.
             
         Raises
@@ -202,7 +202,7 @@ class Browser:
     def new_session_with_backend(self, executable_path="carta", remote_host=None, params=tuple(), timeout=10, token=None):
         """Create a new session after launching a new backend process.
         
-        You can use :obj:`carta.client.Session.start_and_create`, which wraps this method. This method starts a backend process, parses the frontend URL from the output, and calls :obj:`carta.browser.Browser.new_session_from_url`.
+        You can use :obj:`carta.session.Session.start_and_create`, which wraps this method. This method starts a backend process, parses the frontend URL from the output, and calls :obj:`carta.browser.Browser.new_session_from_url`.
         
         Parameters
         ----------
@@ -219,7 +219,7 @@ class Browser:
             
         Returns
         -------
-        :obj:`carta.client.Session`
+        :obj:`carta.session.Session`
             A session object connected to a new frontend session running in this browser.
             
         Raises

--- a/carta/browser.py
+++ b/carta/browser.py
@@ -67,6 +67,8 @@ class Browser:
         protocol = Protocol(frontend_url, token, debug_no_auth=debug_no_auth)
         
         if protocol.controller_auth:
+            # A limitation of Selenium is that to add cookies for a domain you have to be at that domain already.
+            self.driver.get(protocol.frontend_url)
             self.driver.add_cookie(protocol.cookie())
 
         self.driver.get(protocol.frontend_url)

--- a/carta/browser.py
+++ b/carta/browser.py
@@ -1,121 +1,16 @@
 """This module provides browser objects which can be used to create new sessions. It depends on the ``selenium`` library. The desired browser and its corresponding web driver also have to be installed."""
 
-import re
 import time
-import os
-import subprocess
-import pathlib
-import signal
 
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 from selenium.common.exceptions import NoSuchElementException
 
+from .backend import Backend
 from .util import CartaBadSession
-from .session import Session
 from .protocol import Protocol
-from .token import BackendToken
+from .session import Session
 
-
-class Backend:
-    """Helper class for managing a CARTA backend process.
-    
-    You should not need to instantiate this directly; it is created on demand by a :obj:`carta.browser.Browser` object.
-    
-    Parameters
-    ----------
-    params : iterable
-        Parameters to pass to the CARTA backend process.
-    executable_path : string
-        The path to the backend executable. Default: ``"carta"``.
-    remote_host : string
-        If this is set, an attempt will be made to start the backend over ``ssh`` on this host.
-    token : :obj:`carta.token.BackendToken`
-        If this is set, this will be used as the security token and no attempt will be made to parse the token from the backend output.
-    
-    Attributes
-    ----------
-    proc : :obj:`subprocess.Popen`
-        The backend subprocess object. Set by the :obj:`carta.browser.Backend.start` method.
-    frontend_url : string
-        The URL of the running frontend, parsed from the output of the backend process. Set by the :obj:`carta.browser.Backend.start` method.
-    token : :obj:`carta.token.BackendToken`
-        The security token of the running backend, either parsed from the output of the backend process and set by the :obj:`carta.browser.Backend.start` method, or overridden with a parameter.
-    debug_no_auth : boolean
-        If this is set, the backend will accept HTTP connections with no authentication token. This is provided for debugging purposes only and should not be used under normal circumstances. This value is automatically detected from the provided backend parameters.
-    output : list of strings
-        All output of the backend process, split into lines, terminated by newline characters.
-    errors : list of strings
-        Error output of the backend process, split into lines, terminated by newline characters.
-        
-    Returns
-    -------
-    :obj:`carta.browser.Backend`
-        A backend object with a process which has not been started. 
-    
-    """
-    FRONTEND_URL = re.compile(r"CARTA is accessible at (http://.*?:\d+/\?token=(.*))")
-    FRONTEND_URL_NO_AUTH = re.compile(r"CARTA is accessible at (http://(.*?):\d+.*)")
-    
-    def __init__(self, params, executable_path="carta", remote_host=None, token=None):
-        self.proc = None
-        self.frontend_url = None
-        self.token = token
-        self.debug_no_auth = ("--debug_no_auth" in params)
-        self.output = []
-        self.errors = []
-        
-        ssh_cmd = ("ssh", "-tt", remote_host) if remote_host is not None else tuple()
-        self.cmd = tuple(str(p) for p in (*ssh_cmd, executable_path, *params))
-            
-    def start(self):
-        """Start the backend process.
-        
-        This method creates the subprocess object and parses the backend host and the frontend URL from the process output.
-        """
-        # TODO currently we log everything to stdout, but maybe we shouldn't
-        self.proc = subprocess.Popen(self.cmd, stdout=subprocess.PIPE, cwd=pathlib.Path.home(), preexec_fn=os.setpgrp)
-        os.set_blocking(self.proc.stdout.fileno(), False)
-        
-        time.sleep(1)
-        
-        while True:
-            line = self.proc.stdout.readline()
-            if not line:
-                break
-            line = line.decode()
-            
-            self.output.append(line)
-            if "[error]" in line or "[critical]" in line:
-                self.errors.append(line)
-        
-        if self.proc.poll() is not None:
-            return False
-        
-        frontend_url_re = self.FRONTEND_URL if not self.debug_no_auth else self.FRONTEND_URL_NO_AUTH
-        
-        for line in self.output:
-            m = frontend_url_re.search(line)
-            if m:
-                self.frontend_url, token_string = m.groups()
-                break
-        
-        if self.token is None and not self.debug_no_auth:
-            self.token = BackendToken(token_string)
-        
-        return True
-    
-    def stop(self):
-        """Stop the backend process.
-        
-        This method terminates the backend process if it exists and is running.
-        """
-        
-        pgrp = os.getpgid(self.proc.pid)
-        os.killpg(pgrp, signal.SIGINT)
-        self.proc.wait()
-
-# TODO split backend to separate file
 class Browser:
     """The top-level browser class.
     
@@ -147,7 +42,7 @@ class Browser:
             The URL of the frontend.
         token : :obj:`carta.token.Token`, optional
             The security token used by the CARTA instance. May be omitted if the URL contains a token.
-        backend : :obj:`carta.browser.Backend`
+        backend : :obj:`carta.backend.Backend`
             The backend object associated with this session, if any. This is set if this method is called from :obj:`carta.browser.Browser.new_session_with_backend`.
         timeout : number, optional
             The number of seconds to spend parsing the frontend for connection information. 10 seconds by default.

--- a/carta/browser.py
+++ b/carta/browser.py
@@ -173,7 +173,7 @@ class Browser:
         
         if protocol.controller_auth:
             self.driver.add_cookie(protocol.cookie())
-                
+
         self.driver.get(protocol.frontend_url)
         
         session_id = None
@@ -181,7 +181,8 @@ class Browser:
         start = time.time()
         last_error = ""
         
-        while (session_id is None):
+        # Keep trying until the displayed ID is not 0
+        while not session_id:
             if time.time() - start > timeout:
                 break
             
@@ -193,9 +194,9 @@ class Browser:
                 time.sleep(1)
                 continue # retry
         
-        if session_id is None:
+        if not session_id:
             self.exit(f"Could not parse session ID from frontend. Last error: {last_error}")
-        
+                
         return Session(session_id, protocol, browser=self, backend=backend)
     
     def new_session_with_backend(self, executable_path="carta", remote_host=None, params=tuple(), timeout=10, token=None):

--- a/carta/browser.py
+++ b/carta/browser.py
@@ -152,24 +152,24 @@ class Chrome(Browser):
     ----------
     headless : boolean, optional
         Run the browser headless (this is the default).
-    gl : string, optional
-        The value to pass to the ``--use-gl`` flag. The default is ``swiftshader``. Set this to ``None`` to disable setting this flag.
     browser_path : string, optional
         A path to a custom chrome or chromium executable.
     driver_path : string, optional
         A path to a custom chromedriver executable.
+    options : iterable, optional
+        Additional options. A list of strings, one per option (``--option`` or ``--option=argument``).
     """
-    def __init__(self, headless=True, gl="swiftshader", browser_path=None, driver_path=None):
-        options = Options()
+    def __init__(self, headless=True, browser_path=None, driver_path=None, options=tuple()):
+        chrome_options = Options()
         if headless:
-            options.add_argument("--headless")
-        if gl:
-            options.add_argument(f"--use-gl={gl}")
+            chrome_options.add_argument("--headless")
         if browser_path:
-            options.binary_location = browser_path
+            chrome_options.binary_location = browser_path
+        for opt in options:
+            chrome_options.add_argument(opt)
 
         kwargs = {
-            "options": options,
+            "options": chrome_options,
         }
 
         if driver_path:

--- a/carta/browser.py
+++ b/carta/browser.py
@@ -13,16 +13,16 @@ from .session import Session
 
 class Browser:
     """The top-level browser class.
-    
+
     Some common use cases are provided as subclasses, but you may instantiate this class directly to create a browser with custom configuration.
-    
+
     Parameters
     ----------
     driver_class : a selenium web driver class
         The class to use for the browser driver.
     **kwargs
         Keyword arguments which will be passed to the driver class constructor.
-        
+
     Attributes
     ----------
     driver : :obj:`selenium.webdriver.remote.webdriver.WebDriver`
@@ -30,12 +30,12 @@ class Browser:
     """
     def __init__(self, driver_class, **kwargs):
         self.driver = driver_class(**kwargs)
-    
+
     def new_session_from_url(self, frontend_url, token=None, backend=None, timeout=10, debug_no_auth=False):
         """Create a new session by connecting to an existing backend.
-        
+
         You can use :obj:`carta.session.Session.create`, which wraps this method.
-        
+
         Parameters
         ----------
         frontend_url : string
@@ -48,12 +48,12 @@ class Browser:
             The number of seconds to spend parsing the frontend for connection information. 10 seconds by default.
         debug_no_auth : boolean
             Disable authentication. This should be set if the backend has been started with the ``--debug_no_auth`` option. This is provided for debugging purposes only and should not be used under normal circumstances.
-            
+
         Returns
         -------
         :obj:`carta.session.Session`
             A session object connected to a new frontend session running in this browser.
-            
+
         Raises
         ------
         CartaBadToken
@@ -63,26 +63,26 @@ class Browser:
         CartaBadSession
             If the session object could not be created.
         """
-                
+
         protocol = Protocol(frontend_url, token, debug_no_auth=debug_no_auth)
-        
+
         if protocol.controller_auth:
             # A limitation of Selenium is that to add cookies for a domain you have to be at that domain already.
             self.driver.get(protocol.frontend_url)
             self.driver.add_cookie(protocol.cookie())
 
         self.driver.get(protocol.frontend_url)
-        
+
         session_id = None
-        
+
         start = time.time()
         last_error = ""
-        
+
         # Keep trying until the displayed ID is not 0
         while not session_id:
             if time.time() - start > timeout:
                 break
-            
+
             try:
                 # We can't use .text because Selenium is too clever to return the text of invisible elements.
                 session_id = int(self.driver.find_element_by_id("info-session-id").get_attribute("textContent"))
@@ -90,17 +90,17 @@ class Browser:
                 last_error = str(e)
                 time.sleep(1)
                 continue # retry
-        
+
         if not session_id:
             self.exit(f"Could not parse session ID from frontend. Last error: {last_error}")
-                
+
         return Session(session_id, protocol, browser=self, backend=backend)
-    
+
     def new_session_with_backend(self, executable_path="carta", remote_host=None, params=tuple(), timeout=10, token=None):
         """Create a new session after launching a new backend process.
-        
+
         You can use :obj:`carta.session.Session.start_and_create`, which wraps this method. This method starts a backend process, parses the frontend URL from the output, and calls :obj:`carta.browser.Browser.new_session_from_url`.
-        
+
         Parameters
         ----------
         executable_path : string, optional
@@ -113,12 +113,12 @@ class Browser:
             The number of seconds to spend parsing the frontend for connection information. 10 seconds by default.
         token : :obj:`carta.token.BackendToken`, optional
             The security token to use. Parsed from the backend output by default.
-            
+
         Returns
         -------
         :obj:`carta.session.Session`
             A session object connected to a new frontend session running in this browser.
-            
+
         Raises
         ------
         CartaBadToken
@@ -128,20 +128,20 @@ class Browser:
         CartaBadSession
             If the session object could not be created.
         """
-        
+
         backend = Backend(("--no_browser", "--enable_scripting", *params), executable_path, remote_host, token)
         if not backend.start():
             self.exit(f"CARTA backend exited unexpectedly:\n{''.join(backend.errors)}")
-        
+
         if backend.frontend_url is None:
             self.exit("Could not parse CARTA frontend URL from backend output.")
-            
+
         return self.new_session_from_url(backend.frontend_url, backend.token, backend=backend, timeout=timeout, debug_no_auth=backend.debug_no_auth)
-        
+
     def exit(self, msg):
         self.close()
         raise CartaBadSession(msg)
-    
+
     def close(self):
         """Shut down the browser driver."""
         self.driver.quit()

--- a/carta/browser.py
+++ b/carta/browser.py
@@ -11,7 +11,7 @@ from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 from selenium.common.exceptions import NoSuchElementException
 
-from .util import CartaScriptingException
+from .util import CartaBadSession, token_from_url
 from .client import Session
 
 
@@ -158,9 +158,20 @@ class Browser:
         -------
         :obj:`carta.client.Session`
             A session object connected to a new frontend session running in this browser.
+            
+        Raises
+        ------
+        CartaBadSession
+            If the session object could not be created.
         """
         
         # TODO TODO TODO use cookie if it exists
+        
+        if token is None:
+            token = token_from_url(frontend_url)
+            
+        if token is None:
+            self.exit("No token parameter was provided, and no token could be parsed from the URL.")
                 
         self.driver.get(frontend_url)
         
@@ -208,6 +219,11 @@ class Browser:
         -------
         :obj:`carta.client.Session`
             A session object connected to a new frontend session running in this browser.
+            
+        Raises
+        ------
+        CartaBadSession
+            If the session object could not be created.
         """
         
         backend = Backend(("--no_browser", "--enable_scripting", *params), executable_path, remote_host, token)
@@ -221,7 +237,7 @@ class Browser:
         
     def exit(self, msg):
         self.close()
-        raise CartaScriptingException(msg)
+        raise CartaBadSession(msg)
     
     def close(self):
         """Shut down the browser driver."""

--- a/carta/browser.py
+++ b/carta/browser.py
@@ -47,7 +47,7 @@ class Browser:
         timeout : number, optional
             The number of seconds to spend parsing the frontend for connection information. 10 seconds by default.
         debug_no_auth : boolean
-            This should be set if the backend has been started with the ``--debug_no_auth`` option. This is provided for debugging purposes only and should not be used under normal circumstances. You must still pass in a *token* argument if you use this option, but you may set it to ``None``. It will be ignored.
+            Disable authentication. This should be set if the backend has been started with the ``--debug_no_auth`` option. This is provided for debugging purposes only and should not be used under normal circumstances.
             
         Returns
         -------

--- a/carta/browser.py
+++ b/carta/browser.py
@@ -11,6 +11,7 @@ from .util import CartaBadSession
 from .protocol import Protocol
 from .session import Session
 
+
 class Browser:
     """The top-level browser class.
 
@@ -28,6 +29,7 @@ class Browser:
     driver : :obj:`selenium.webdriver.remote.webdriver.WebDriver`
         The browser driver.
     """
+
     def __init__(self, driver_class, **kwargs):
         self.driver = driver_class(**kwargs)
 
@@ -89,7 +91,7 @@ class Browser:
             except (NoSuchElementException, ValueError) as e:
                 last_error = str(e)
                 time.sleep(1)
-                continue # retry
+                continue  # retry
 
         if not session_id:
             self.exit(f"Could not parse session ID from frontend. Last error: {last_error}")
@@ -161,6 +163,7 @@ class Chrome(Browser):
     options : iterable, optional
         Additional options. A list of strings, one per option (``--option`` or ``--option=argument``).
     """
+
     def __init__(self, headless=True, browser_path=None, driver_path=None, options=tuple()):
         chrome_options = Options()
         if headless:

--- a/carta/browser.py
+++ b/carta/browser.py
@@ -152,15 +152,19 @@ class Chrome(Browser):
     ----------
     headless : boolean, optional
         Run the browser headless (this is the default).
+    gl : string, optional
+        The value to pass to the ``--use-gl`` flag. The default is ``swiftshader``. Set this to ``None`` to disable setting this flag.
     browser_path : string, optional
         A path to a custom chrome or chromium executable.
     driver_path : string, optional
         A path to a custom chromedriver executable.
     """
-    def __init__(self, headless=True, browser_path=None, driver_path=None):
+    def __init__(self, headless=True, gl="swiftshader", browser_path=None, driver_path=None):
         options = Options()
         if headless:
             options.add_argument("--headless")
+        if gl:
+            options.add_argument(f"--use-gl={gl}")
         if browser_path:
             options.binary_location = browser_path
 

--- a/carta/client.py
+++ b/carta/client.py
@@ -165,7 +165,7 @@ class Session:
         *args
             A variable-length list of parameters to pass to the action. :obj:`carta.util.Macro` objects may be used to refer to frontend objects which will be evaluated dynamically. This parameter list will be serialized into a JSON string with :obj:`carta.util.CartaEncoder`.
         **kwargs
-            Arbitrary keyword arguments. At present only three are used: *async* (boolean) is passed to indicate that an action is asynchronous (but this currently has no effect). *response_expected* (boolean) indicates that the action should return a JSON object. *return_path* specifies a subobject of the action's response which should be returned instead of the whole response.
+            Arbitrary keyword arguments. At present only three are used: *async* (boolean) is passed to indicate that the request should return a response as soon as the action is called, without waiting for the action to complete. *response_expected* (boolean) indicates that the action should return a JSON object. This is set automatically if *return_path* is set. *return_path* specifies a subobject of the action's response which should be returned instead of the whole response. *timeout* (boolean) is the maximum time in seconds to wait for an action request to complete (the default is 10).
         
         Returns
         -------
@@ -180,7 +180,7 @@ class Session:
             If a request which was expected to have a JSON response did not have one, or if a JSON response could not be decoded.
         """
         try:
-            self._protocol.request_scripting_action(self.session_id, path, *args, **kwargs)
+            return self._protocol.request_scripting_action(self.session_id, path, *args, **kwargs)
         except CartaScriptingException:
             self.close()
             raise

--- a/carta/client.py
+++ b/carta/client.py
@@ -568,7 +568,7 @@ class Session:
             args.append(background_color)
         return self.call_action(*args, response_expected=True)
     
-    @validate(Color())
+    @validate(NoneOr(Color()))
     def rendered_view_data(self, background_color=None):
         """Get the decoded data of the rendered active image.
         
@@ -587,7 +587,7 @@ class Session:
         data = uri.split(",")[1]
         return base64.b64decode(data)
     
-    @validate(String(), Color())
+    @validate(String(), NoneOr(Color()))
     def save_rendered_view(self, file_name, background_color=None):
         """Save the decoded data of the rendered active image to a file.
         

--- a/carta/client.py
+++ b/carta/client.py
@@ -180,7 +180,7 @@ class Session:
             If a request which was expected to have a JSON response did not have one, or if a JSON response could not be decoded.
         """
         try:
-            self._protocol.request_scripting_action(self.session_id, path, args, kwargs)
+            self._protocol.request_scripting_action(self.session_id, path, *args, **kwargs)
         except CartaScriptingException:
             self.close()
             raise

--- a/carta/client.py
+++ b/carta/client.py
@@ -252,7 +252,7 @@ class Session:
         if "files" in file_list:
             items.extend([f["name"] for f in file_list["files"]])
         if "subdirectories" in file_list:
-            items.extend([f"{d}/" for d in file_list["subdirectories"]])
+            items.extend([f"{d['name']}/" for d in file_list["subdirectories"]])
         return sorted(items)
     
     def cd(self, path):

--- a/carta/constants.py
+++ b/carta/constants.py
@@ -1,8 +1,10 @@
 """This module provides a collection of classes corresponding to various enumerated types and other literal lists of options defined in the frontend. The properties of these classes should be used in place of literal strings and numbers to represent these values; for example: ``Colormap.VIRIDIS`` rather than ``"viridis"``. """
 
+
 class Colormap:
     """All available colormaps."""
     pass
+
 
 for colormap in ('copper', 'paired', 'gist_heat', 'brg', 'cool', 'summer', 'OrRd', 'tab20c', 'purples', 'gray', 'terrain', 'RdPu', 'set2', 'spring', 'gist_yarg', 'RdYlBu', 'reds', 'winter', 'Wistia', 'rainbow', 'dark2', 'oranges', 'BuPu', 'gist_earth', 'PuBu', 'pink', 'PuOr', 'pastel2', 'PiYG', 'gist_ncar', 'PuRd', 'plasma', 'gist_stern', 'hot', 'PuBuGn', 'YlOrRd', 'accent', 'magma', 'set1', 'GnBu', 'greens', 'CMRmap', 'gist_rainbow', 'prism', 'hsv', 'Blues', 'viridis', 'YlGn', 'spectral', 'RdBu', 'tab20', 'greys', 'flag', 'jet', 'seismic', 'PRGn', 'coolwarm', 'YlOrBr', 'RdYlGn', 'bone', 'autumn', 'BrBG', 'gnuplot2', 'RdGy', 'binary', 'gnuplot', 'BuGn', 'gist_gray', 'nipy_spectral', 'set3', 'tab20b', 'pastel1', 'afmhot', 'cubehelix', 'YlGnBu', 'ocean', 'tab10', 'bwr', 'inferno'):
     setattr(Colormap, colormap.upper(), colormap)
@@ -16,6 +18,7 @@ class Scaling:
 class CoordinateSystem:
     """Coordinate systems."""
     pass
+
 
 for system in ("Auto", "Ecliptic", "FK4", "FK5", "Galactic", "ICRS"):
     setattr(CoordinateSystem, system.upper(), system)
@@ -43,7 +46,8 @@ class Overlay:
 
     The values of these properties are paths to stores corresponding to these elements, relative to the overlay store.
     """
-    BEAM = "beam.settingsForDisplay" # special case: an extra layer of indirection
+    BEAM = "beam.settingsForDisplay"  # special case: an extra layer of indirection
+
 
 for component in ("global", "title", "grid", "border", "ticks", "axes", "numbers", "labels"):
     setattr(Overlay, component.upper(), component)

--- a/carta/constants.py
+++ b/carta/constants.py
@@ -40,7 +40,7 @@ class PaletteColor:
 
 class Overlay:
     """Overlay elements.
-    
+
     The values of these properties are paths to stores corresponding to these elements, relative to the overlay store.
     """
     BEAM = "beam.settingsForDisplay" # special case: an extra layer of indirection
@@ -48,11 +48,11 @@ class Overlay:
 for component in ("global", "title", "grid", "border", "ticks", "axes", "numbers", "labels"):
     setattr(Overlay, component.upper(), component)
 
-    
+
 class SmoothingMode:
     """Contour smoothing modes."""
     NO_SMOOTHING, BLOCK_AVERAGE, GAUSSIAN_BLUR = range(3)
-    
+
 
 class ContourDashMode:
     """Contour dash modes."""

--- a/carta/image.py
+++ b/carta/image.py
@@ -31,7 +31,6 @@ class Image:
         The ID identifying this image within the session.
     file_name : string
         The file name of the image.
-
     """
 
     def __init__(self, session, image_id, file_name):
@@ -109,8 +108,8 @@ class Image:
 
         Returns
         -------
-            object or None
-                The unmodified return value of the session method.
+        object or None
+            The unmodified return value of the session method.
         """
         return self.session.call_action(f"{self._base_path}.{path}", *args, **kwargs)
 
@@ -126,8 +125,8 @@ class Image:
 
         Returns
         -------
-            object
-                The unmodified return value of the session method.
+        object
+            The unmodified return value of the session method.
         """
         return self.session.get_value(f"{self._base_path}.{path}")
 
@@ -136,49 +135,105 @@ class Image:
     @property
     @cached
     def directory(self):
-        """The path to the directory containing the image."""
+        """The path to the directory containing the image.
+
+        Returns
+        -------
+        string
+            The directory path.
+        """
         return self.get_value("frameInfo.directory")
 
     @property
     @cached
     def header(self):
-        """The header of the image."""
-        return self.get_value("frameInfo.fileInfoExtended.headerEntries")
+        """The header of the image.
+
+        Returns
+        -------
+        dict of string to string, integer, float or boolean
+            The header of the image, with field names as keys. T or F string values are automatically converted to booleans.
+        """
+        raw_header = self.get_value("frameInfo.fileInfoExtended.headerEntries")
+        header = {e["name"]: e.get("numericValue", e["value"]) for e in raw_header}
+        for k, v in header.items():
+            if v == 'T':
+                header[k] = True
+            elif v == 'F':
+                header[k] = False
+        return header
 
     @property
     @cached
     def shape(self):
-        """The shape of the image."""
+        """The shape of the image.
+
+        Returns
+        -------
+        list of integers
+            The shape of the image; dimensions ordered with width last.
+
+        """
         return list(reversed([self.width, self.height, self.depth, self.stokes][:self.ndim]))
 
     @property
     @cached
     def width(self):
-        """The width of the image."""
+        """The width of the image.
+
+        Returns
+        -------
+        integer
+            The width.
+        """
         return self.get_value("frameInfo.fileInfoExtended.width")
 
     @property
     @cached
     def height(self):
-        """The height of the image."""
+        """The height of the image.
+
+        Returns
+        -------
+        integer
+            The height.
+        """
         return self.get_value("frameInfo.fileInfoExtended.height")
 
     @property
     @cached
     def depth(self):
-        """The depth of the image."""
+        """The depth of the image.
+
+        Returns
+        -------
+        integer
+            The depth.
+        """
         return self.get_value("frameInfo.fileInfoExtended.depth")
 
     @property
     @cached
     def stokes(self):
-        """The number of Stokes parameters of the image."""
+        """The number of Stokes parameters of the image.
+
+        Returns
+        -------
+        integer
+            The number of Stokes parameters.
+        """
         return self.get_value("frameInfo.fileInfoExtended.stokes")
 
     @property
     @cached
     def ndim(self):
-        """The number of dimensions of the image."""
+        """The number of dimensions of the image.
+
+        Returns
+        -------
+        integer
+            The number of dimensions.
+        """
         return self.get_value("frameInfo.fileInfoExtended.dimensions")
 
     # SELECTION

--- a/carta/image.py
+++ b/carta/image.py
@@ -1,0 +1,463 @@
+"""This module contains an image class which represents a single image open in the session.
+
+Image objects should not be instantiated directly, and should only be created through methods on the :obj:`carta.session.Session` object.
+"""
+import posixpath
+
+from .constants import Colormap, Scaling, SmoothingMode, ContourDashMode
+from .util import Macro, cached
+from .validation import validate, Number, Color, Constant, Boolean, NoneOr, IterableOf, Evaluate, Attr
+
+class Image:
+    """This object corresponds to an image open in a CARTA frontend session.
+    
+    This class should not be instantiated directly. Instead, use the session object's methods for opening new images or retrieving existing images.
+    
+    Parameters
+    ----------
+    session : :obj:`carta.session.Session`
+        The session object associated with this image.
+    image_id : integer
+        The ID identifying this image within the session. This is a unique number which is not reused, not the index of the image within the list of currently open images.
+    file_name : string
+        The file name of the image. This is not a full path.
+    
+    Attributes
+    ----------
+    session : :obj:`carta.session.Session`
+        The session object associated with this image.
+    image_id : integer
+        The ID identifying this image within the session.
+    file_name : string
+        The file name of the image.
+    
+    """
+    def __init__(self, session, image_id, file_name):
+        self.session = session
+        self.image_id = image_id
+        self.file_name = file_name
+        
+        self._base_path = f"frameMap[{image_id}]"
+        self._frame = Macro("", self._base_path)
+    
+    @classmethod
+    def new(cls, session, path, hdu, append):
+        """Open or append a new image in the session and return an image object associated with it.
+        
+        This method should not be used directly. It is wrapped by :obj:`carta.session.Session.open_image` and :obj:`carta.session.Session.append_image`.
+        
+        Parameters
+        ----------
+        session : :obj:`carta.session.Session`
+            The session object.
+        path : string
+            The path to the image file, either relative to the session's current directory or an absolute path relative to the CARTA backend's root directory.
+        hdu : string
+            The HDU to open.
+        append : boolean
+            Whether the image should be appended. By default it is not, and all other open images are closed.
+        
+        Returns
+        -------
+        :obj:`carta.image.Image`
+            A new image object.
+        """
+        path = session.resolve_file_path(path)
+        directory, file_name = posixpath.split(path)
+        image_id = session.call_action("appendFile" if append else "openFile", directory, file_name, hdu, return_path="frameInfo.fileId")
+        
+        return cls(session, image_id, file_name)
+    
+    @classmethod
+    def from_list(cls, session, image_list):
+        """Create a list of image objects from a list of open images retrieved from the frontend.
+        
+        This method should not be used directly. It is wrapped by :obj:`carta.session.Session.image_list`.
+        
+        Parameters
+        ----------
+        session : :obj:`carta.session.Session`
+            The session object.
+        image_list : list of dicts
+            The JSON object representing frame names retrieved from the frontend.
+            
+        Returns
+        -------
+        list of :obj:`carta.image.Image`
+            A list of new image objects.
+        """
+        return [cls(session, f["value"], f["label"].split(":")[1].strip()) for f in image_list]
+        
+    def __repr__(self):
+        return f"{self.session.session_id}:{self.image_id}:{self.file_name}"
+    
+    def call_action(self, path, *args, **kwargs):
+        """Convenience wrapper for the session object's generic action method.
+        
+        This method calls :obj:`carta.session.Session.call_action` after prepending this image's base path to the path parameter.
+        
+        Parameters
+        ----------
+        path : string
+            The path to an action relative to this image's frame store.
+        *args
+            A variable-length list of parameters. These are passed unmodified to the session method.
+        **kwargs
+            Arbitrary keyword parameters. These are passed unmodified to the session method.
+        
+        Returns
+        -------
+            object or None
+                The unmodified return value of the session method.
+        """
+        return self.session.call_action(f"{self._base_path}.{path}", *args, **kwargs)
+    
+    def get_value(self, path):
+        """Convenience wrapper for the session object's generic method for retrieving attribute values.
+        
+        This method calls :obj:`carta.session.Session.get_value` after prepending this image's base path to the path parameter.
+        
+        Parameters
+        ----------
+        path : string
+            The path to an attribute relative to this image's frame store.
+        
+        Returns
+        -------
+            object
+                The unmodified return value of the session method.
+        """
+        return self.session.get_value(f"{self._base_path}.{path}")
+    
+    # METADATA
+    
+    @property
+    @cached
+    def directory(self):
+        """The path to the directory containing the image."""
+        return self.get_value("frameInfo.directory")
+    
+    @property
+    @cached
+    def header(self):
+        """The header of the image."""
+        return self.get_value("frameInfo.fileInfoExtended.headerEntries")
+    
+    @property
+    @cached
+    def shape(self):
+        """The shape of the image."""
+        return list(reversed([self.width, self.height, self.depth, self.stokes][:self.ndim]))
+    
+    @property
+    @cached
+    def width(self):
+        """The width of the image."""
+        return self.get_value("frameInfo.fileInfoExtended.width")
+    
+    @property
+    @cached
+    def height(self):
+        """The height of the image."""
+        return self.get_value("frameInfo.fileInfoExtended.height")
+    
+    @property
+    @cached
+    def depth(self):
+        """The depth of the image."""
+        return self.get_value("frameInfo.fileInfoExtended.depth")
+    
+    @property
+    @cached
+    def stokes(self):
+        """The number of Stokes parameters of the image."""
+        return self.get_value("frameInfo.fileInfoExtended.stokes")
+    
+    @property
+    @cached
+    def ndim(self):
+        """The number of dimensions of the image."""
+        return self.get_value("frameInfo.fileInfoExtended.dimensions")
+    
+    # SELECTION
+    
+    def make_active(self):
+        """Make this the active image."""
+        self.session.call_action("setActiveFrameById", self.image_id)
+        
+    def make_spatial_reference(self):
+        """Make this image the spatial reference."""
+        self.session.call_action("setSpatialReference", self._frame)
+        
+    @validate(Boolean())
+    def set_spatial_matching(self, state):
+        """Enable or disable spatial matching.
+        
+        Parameters
+        ----------
+        state : boolean
+            The desired spatial matching state.
+        """
+        self.session.call_action("setSpatialMatchingEnabled", self._frame, state)
+        
+    def make_spectral_reference(self):
+        """Make this image the spectral reference."""
+        self.session.call_action("setSpectralReference", self._frame)
+        
+    @validate(Boolean())
+    def set_spectral_matching(self, state):
+        """Enable or disable spectral matching.
+        
+        Parameters
+        ----------
+        state : boolean
+            The desired spectral matching state.
+        """
+        self.session.call_action("setSpectralMatchingEnabled", self._frame, state)
+
+    # NAVIGATION
+
+    @validate(Evaluate(Number, 0, Attr("depth"), Number.INCLUDE_MIN), Evaluate(Number, 0, Attr("stokes"), Number.INCLUDE_MIN), Boolean())
+    def set_channel_stokes(self, channel=None, stokes=None, recursive=True):
+        """Set the channel and/or Stokes.
+        
+        Parameters
+        ----------
+        channel : {0}
+            The desired channel. Defaults to the current channel.
+        stokes : {1}
+            The desired stokes. Defaults to the current Stokes.
+        recursive : {2}
+            Whether to perform the same change on all spectrally matched images. Defaults to True.
+        """
+        channel = channel or self.get_value("requiredChannel")
+        stokes = stokes or self.get_value("requiredStokes")
+        self.call_action("setChannels", channel, stokes, recursive)
+
+    @validate(Number(), Number())
+    def set_center(self, x, y):
+        """Set the center position.
+        
+        TODO: what are the units?
+        
+        Parameters
+        ----------
+        x : {0}
+            The X position.
+        y : {1}
+            The Y position.
+        """
+        self.call_action("setCenter", x, y)
+        
+    @validate(Number(), Boolean())
+    def set_zoom(self, zoom, absolute=True):
+        """Set the zoom level.
+        
+        TODO: explain this more rigorously.
+        
+        Parameters
+        ----------
+        zoom : {0}
+            The zoom level.
+        absolute : {1}
+            Whether the zoom level should be treated as absolute. By default it is adjusted by a scaling factor.
+        """
+        self.call_action("setZoom", zoom, absolute)
+        
+    # STYLE
+
+    @validate(Constant(Colormap), Boolean())
+    def set_colormap(self, colormap, invert=False):
+        """Set the colormap.
+        
+        Parameters
+        ----------
+        colormap : {0}
+            The colormap.
+        invert : {1}
+            Whether the colormap should be inverted.
+        """
+        self.call_action("renderConfig.setColorMap", colormap)
+        self.call_action("renderConfig.setInverted", invert)
+    
+    # TODO check whether this works as expected
+    @validate(Constant(Scaling), NoneOr(Number()), NoneOr(Number()), NoneOr(Number()), NoneOr(Number()))
+    def set_scaling(self, scaling, alpha=None, gamma=None, min=None, max=None):
+        """Set the colormap scaling.
+        
+        Parameters
+        ----------
+        scaling : {0}
+            The scaling type.
+        alpha : {1}
+            The alpha value (only applicable to ``LOG`` and ``POWER`` scaling types).
+        gamma : {2}
+            The gamma value (only applicable to the ``GAMMA`` scaling type).
+        min : {3}
+            The minimum of the scale. Only used if both *min* and *max* are set.
+        max : {4}
+            The maximum of the scale. Only used if both *min* and *max* are set.
+        """
+        self.call_action("renderConfig.setScaling", scaling)
+        if scaling in (Scaling.LOG, Scaling.POWER) and alpha is not None:
+            self.call_action("renderConfig.setAlpha", alpha)
+        elif scaling == Scaling.GAMMA and gamma is not None:
+            self.call_action("renderConfig.setGamma", gamma)
+        if min is not None and max is not None:
+            self.call_action("renderConfig.setCustomScale", min, max)
+    
+    @validate(Boolean())
+    def set_raster_visible(self, state):
+        """Set the raster image visibility.
+        
+        Parameters
+        ----------
+        state : {0}
+            The desired visibility state.
+        """
+        self.call_action("renderConfig.setVisible", state)
+        
+    def show_raster(self):
+        """Show the raster image."""
+        self.set_raster_visible(True)
+        
+    def hide_raster(self):
+        """Hide the raster image."""
+        self.set_raster_visible(False)
+    
+    # CONTOURS
+    
+    @validate(IterableOf(Number()), Constant(SmoothingMode), Number())
+    def configure_contours(self, levels, smoothing_mode=SmoothingMode.GAUSSIAN_BLUR, smoothing_factor=4):
+        """Configure contours.
+        
+        Parameters
+        ----------
+        levels : {0}
+            The contour levels. This may be a numeric numpy array; e.g. the output of ``arange``.
+        smoothing_mode : {1}
+            The smoothing mode.
+        smoothing_factor : {2}
+            The smoothing factor.
+        """
+        self.call_action("contourConfig.setContourConfiguration", levels, smoothing_mode, smoothing_factor)
+    
+    @validate(NoneOr(Constant(ContourDashMode)), NoneOr(Number()))
+    def set_contour_dash(self, dash_mode=None, thickness=None):
+        """Set the contour dash style.
+        
+        Parameters
+        ----------
+        dash_mode : {0}
+            The dash mode.
+        thickness : {1}
+            The dash thickness.
+        """
+        if dash_mode is not None:
+            self.call_action("contourConfig.setDashMode", dash_mode)
+        if thickness is not None:
+            self.call_action("contourConfig.setThickness", thickness)
+    
+    @validate(Color())
+    def set_contour_color(self, color):
+        """Set the contour color.
+        
+        This automatically disables use of the contour colormap.
+        
+        Parameters
+        ----------
+        color : {0}
+            The color.
+        """
+        self.call_action("contourConfig.setColor", color)
+        self.call_action("contourConfig.setColormapEnabled", False)
+    
+    @validate(Constant(Colormap), NoneOr(Number()), NoneOr(Number()))
+    def set_contour_colormap(self, colormap, bias=None, contrast=None):
+        """Set the contour colormap.
+        
+        This automatically enables use of the contour colormap.
+        
+        Parameters
+        ----------
+        colormap : {0}
+            The colormap.
+        bias : {1}
+            The colormap bias.
+        contrast : {2}
+            The colormap contrast.
+        """
+        self.call_action("contourConfig.setColormap", colormap)
+        self.call_action("contourConfig.setColormapEnabled", True)
+        if bias is not None:
+            self.call_action("contourConfig.setColormapBias", bias)
+        if contrast is not None:
+            self.call_action("contourConfig.setColormapContrast", contrast)
+    
+    def apply_contours(self):
+        """Apply the contour configuration."""
+        self.call_action("applyContours")
+    
+    def clear_contours(self):
+        """Clear the contours."""
+        self.call_action("clearContours", True)
+    
+    @validate(Boolean())
+    def set_contours_visible(self, state):
+        """Set the contour visibility.
+        
+        Parameters
+        ----------
+        state : {0}
+            The desired visibility state.
+        """
+        self.call_action("contourConfig.setVisible", state)
+    
+    def show_contours(self):
+        """Show the contours."""
+        self.set_contours_visible(True)
+        
+    def hide_contours(self):
+        """Hide the contours."""
+        self.set_contours_visible(False)
+    
+    # HISTOGRAM
+    
+    @validate(Boolean())
+    def use_cube_histogram(self, contours=False):
+        """Use the cube histogram.
+        
+        Parameters
+        ----------
+        contours : {0}
+            Apply to the contours. By default this is applied to the raster image.
+        """
+        self.call_action(f"renderConfig.setUseCubeHistogram{'Contours' if contours else ''}", True)
+    
+    @validate(Boolean())
+    def use_channel_histogram(self, contours=False):
+        """Use the channel histogram.
+        
+        Parameters
+        ----------
+        contours : {0}
+            Apply to the contours. By default this is applied to the raster image.
+        """
+        self.call_action(f"renderConfig.setUseCubeHistogram{'Contours' if contours else ''}", False)
+            
+    @validate(Number(0, 100))
+    def set_percentile_rank(self, rank):
+        """Set the percentile rank.
+        
+        Parameters
+        ----------
+        rank : {0}
+            The percentile rank.
+        """
+        self.call_action("renderConfig.setPercentileRank", rank)
+    
+    # CLOSE
+    
+    def close(self):
+        """Close this image."""
+        self.session.call_action("closeFile", self._frame)

--- a/carta/image.py
+++ b/carta/image.py
@@ -8,6 +8,7 @@ from .constants import Colormap, Scaling, SmoothingMode, ContourDashMode
 from .util import Macro, cached
 from .validation import validate, Number, Color, Constant, Boolean, NoneOr, IterableOf, Evaluate, Attr
 
+
 class Image:
     """This object corresponds to an image open in a CARTA frontend session.
 
@@ -32,6 +33,7 @@ class Image:
         The file name of the image.
 
     """
+
     def __init__(self, session, image_id, file_name):
         self.session = session
         self.image_id = image_id

--- a/carta/image.py
+++ b/carta/image.py
@@ -10,9 +10,9 @@ from .validation import validate, Number, Color, Constant, Boolean, NoneOr, Iter
 
 class Image:
     """This object corresponds to an image open in a CARTA frontend session.
-    
+
     This class should not be instantiated directly. Instead, use the session object's methods for opening new images or retrieving existing images.
-    
+
     Parameters
     ----------
     session : :obj:`carta.session.Session`
@@ -21,7 +21,7 @@ class Image:
         The ID identifying this image within the session. This is a unique number which is not reused, not the index of the image within the list of currently open images.
     file_name : string
         The file name of the image. This is not a full path.
-    
+
     Attributes
     ----------
     session : :obj:`carta.session.Session`
@@ -30,22 +30,22 @@ class Image:
         The ID identifying this image within the session.
     file_name : string
         The file name of the image.
-    
+
     """
     def __init__(self, session, image_id, file_name):
         self.session = session
         self.image_id = image_id
         self.file_name = file_name
-        
+
         self._base_path = f"frameMap[{image_id}]"
         self._frame = Macro("", self._base_path)
-    
+
     @classmethod
     def new(cls, session, path, hdu, append):
         """Open or append a new image in the session and return an image object associated with it.
-        
+
         This method should not be used directly. It is wrapped by :obj:`carta.session.Session.open_image` and :obj:`carta.session.Session.append_image`.
-        
+
         Parameters
         ----------
         session : :obj:`carta.session.Session`
@@ -56,7 +56,7 @@ class Image:
             The HDU to open.
         append : boolean
             Whether the image should be appended. By default it is not, and all other open images are closed.
-        
+
         Returns
         -------
         :obj:`carta.image.Image`
@@ -65,37 +65,37 @@ class Image:
         path = session.resolve_file_path(path)
         directory, file_name = posixpath.split(path)
         image_id = session.call_action("appendFile" if append else "openFile", directory, file_name, hdu, return_path="frameInfo.fileId")
-        
+
         return cls(session, image_id, file_name)
-    
+
     @classmethod
     def from_list(cls, session, image_list):
         """Create a list of image objects from a list of open images retrieved from the frontend.
-        
+
         This method should not be used directly. It is wrapped by :obj:`carta.session.Session.image_list`.
-        
+
         Parameters
         ----------
         session : :obj:`carta.session.Session`
             The session object.
         image_list : list of dicts
             The JSON object representing frame names retrieved from the frontend.
-            
+
         Returns
         -------
         list of :obj:`carta.image.Image`
             A list of new image objects.
         """
         return [cls(session, f["value"], f["label"].split(":")[1].strip()) for f in image_list]
-        
+
     def __repr__(self):
         return f"{self.session.session_id}:{self.image_id}:{self.file_name}"
-    
+
     def call_action(self, path, *args, **kwargs):
         """Convenience wrapper for the session object's generic action method.
-        
+
         This method calls :obj:`carta.session.Session.call_action` after prepending this image's base path to the path parameter.
-        
+
         Parameters
         ----------
         path : string
@@ -104,110 +104,110 @@ class Image:
             A variable-length list of parameters. These are passed unmodified to the session method.
         **kwargs
             Arbitrary keyword parameters. These are passed unmodified to the session method.
-        
+
         Returns
         -------
             object or None
                 The unmodified return value of the session method.
         """
         return self.session.call_action(f"{self._base_path}.{path}", *args, **kwargs)
-    
+
     def get_value(self, path):
         """Convenience wrapper for the session object's generic method for retrieving attribute values.
-        
+
         This method calls :obj:`carta.session.Session.get_value` after prepending this image's base path to the path parameter.
-        
+
         Parameters
         ----------
         path : string
             The path to an attribute relative to this image's frame store.
-        
+
         Returns
         -------
             object
                 The unmodified return value of the session method.
         """
         return self.session.get_value(f"{self._base_path}.{path}")
-    
+
     # METADATA
-    
+
     @property
     @cached
     def directory(self):
         """The path to the directory containing the image."""
         return self.get_value("frameInfo.directory")
-    
+
     @property
     @cached
     def header(self):
         """The header of the image."""
         return self.get_value("frameInfo.fileInfoExtended.headerEntries")
-    
+
     @property
     @cached
     def shape(self):
         """The shape of the image."""
         return list(reversed([self.width, self.height, self.depth, self.stokes][:self.ndim]))
-    
+
     @property
     @cached
     def width(self):
         """The width of the image."""
         return self.get_value("frameInfo.fileInfoExtended.width")
-    
+
     @property
     @cached
     def height(self):
         """The height of the image."""
         return self.get_value("frameInfo.fileInfoExtended.height")
-    
+
     @property
     @cached
     def depth(self):
         """The depth of the image."""
         return self.get_value("frameInfo.fileInfoExtended.depth")
-    
+
     @property
     @cached
     def stokes(self):
         """The number of Stokes parameters of the image."""
         return self.get_value("frameInfo.fileInfoExtended.stokes")
-    
+
     @property
     @cached
     def ndim(self):
         """The number of dimensions of the image."""
         return self.get_value("frameInfo.fileInfoExtended.dimensions")
-    
+
     # SELECTION
-    
+
     def make_active(self):
         """Make this the active image."""
         self.session.call_action("setActiveFrameById", self.image_id)
-        
+
     def make_spatial_reference(self):
         """Make this image the spatial reference."""
         self.session.call_action("setSpatialReference", self._frame)
-        
+
     @validate(Boolean())
     def set_spatial_matching(self, state):
         """Enable or disable spatial matching.
-        
+
         Parameters
         ----------
         state : boolean
             The desired spatial matching state.
         """
         self.session.call_action("setSpatialMatchingEnabled", self._frame, state)
-        
+
     def make_spectral_reference(self):
         """Make this image the spectral reference."""
         self.session.call_action("setSpectralReference", self._frame)
-        
+
     @validate(Boolean())
     def set_spectral_matching(self, state):
         """Enable or disable spectral matching.
-        
+
         Parameters
         ----------
         state : boolean
@@ -220,7 +220,7 @@ class Image:
     @validate(Evaluate(Number, 0, Attr("depth"), Number.INCLUDE_MIN), Evaluate(Number, 0, Attr("stokes"), Number.INCLUDE_MIN), Boolean())
     def set_channel_stokes(self, channel=None, stokes=None, recursive=True):
         """Set the channel and/or Stokes.
-        
+
         Parameters
         ----------
         channel : {0}
@@ -237,9 +237,9 @@ class Image:
     @validate(Number(), Number())
     def set_center(self, x, y):
         """Set the center position.
-        
+
         TODO: what are the units?
-        
+
         Parameters
         ----------
         x : {0}
@@ -248,13 +248,13 @@ class Image:
             The Y position.
         """
         self.call_action("setCenter", x, y)
-        
+
     @validate(Number(), Boolean())
     def set_zoom(self, zoom, absolute=True):
         """Set the zoom level.
-        
+
         TODO: explain this more rigorously.
-        
+
         Parameters
         ----------
         zoom : {0}
@@ -263,13 +263,13 @@ class Image:
             Whether the zoom level should be treated as absolute. By default it is adjusted by a scaling factor.
         """
         self.call_action("setZoom", zoom, absolute)
-        
+
     # STYLE
 
     @validate(Constant(Colormap), Boolean())
     def set_colormap(self, colormap, invert=False):
         """Set the colormap.
-        
+
         Parameters
         ----------
         colormap : {0}
@@ -279,12 +279,12 @@ class Image:
         """
         self.call_action("renderConfig.setColorMap", colormap)
         self.call_action("renderConfig.setInverted", invert)
-    
+
     # TODO check whether this works as expected
     @validate(Constant(Scaling), NoneOr(Number()), NoneOr(Number()), NoneOr(Number()), NoneOr(Number()))
     def set_scaling(self, scaling, alpha=None, gamma=None, min=None, max=None):
         """Set the colormap scaling.
-        
+
         Parameters
         ----------
         scaling : {0}
@@ -305,32 +305,32 @@ class Image:
             self.call_action("renderConfig.setGamma", gamma)
         if min is not None and max is not None:
             self.call_action("renderConfig.setCustomScale", min, max)
-    
+
     @validate(Boolean())
     def set_raster_visible(self, state):
         """Set the raster image visibility.
-        
+
         Parameters
         ----------
         state : {0}
             The desired visibility state.
         """
         self.call_action("renderConfig.setVisible", state)
-        
+
     def show_raster(self):
         """Show the raster image."""
         self.set_raster_visible(True)
-        
+
     def hide_raster(self):
         """Hide the raster image."""
         self.set_raster_visible(False)
-    
+
     # CONTOURS
-    
+
     @validate(IterableOf(Number()), Constant(SmoothingMode), Number())
     def configure_contours(self, levels, smoothing_mode=SmoothingMode.GAUSSIAN_BLUR, smoothing_factor=4):
         """Configure contours.
-        
+
         Parameters
         ----------
         levels : {0}
@@ -341,11 +341,11 @@ class Image:
             The smoothing factor.
         """
         self.call_action("contourConfig.setContourConfiguration", levels, smoothing_mode, smoothing_factor)
-    
+
     @validate(NoneOr(Constant(ContourDashMode)), NoneOr(Number()))
     def set_contour_dash(self, dash_mode=None, thickness=None):
         """Set the contour dash style.
-        
+
         Parameters
         ----------
         dash_mode : {0}
@@ -357,13 +357,13 @@ class Image:
             self.call_action("contourConfig.setDashMode", dash_mode)
         if thickness is not None:
             self.call_action("contourConfig.setThickness", thickness)
-    
+
     @validate(Color())
     def set_contour_color(self, color):
         """Set the contour color.
-        
+
         This automatically disables use of the contour colormap.
-        
+
         Parameters
         ----------
         color : {0}
@@ -371,13 +371,13 @@ class Image:
         """
         self.call_action("contourConfig.setColor", color)
         self.call_action("contourConfig.setColormapEnabled", False)
-    
+
     @validate(Constant(Colormap), NoneOr(Number()), NoneOr(Number()))
     def set_contour_colormap(self, colormap, bias=None, contrast=None):
         """Set the contour colormap.
-        
+
         This automatically enables use of the contour colormap.
-        
+
         Parameters
         ----------
         colormap : {0}
@@ -393,71 +393,71 @@ class Image:
             self.call_action("contourConfig.setColormapBias", bias)
         if contrast is not None:
             self.call_action("contourConfig.setColormapContrast", contrast)
-    
+
     def apply_contours(self):
         """Apply the contour configuration."""
         self.call_action("applyContours")
-    
+
     def clear_contours(self):
         """Clear the contours."""
         self.call_action("clearContours", True)
-    
+
     @validate(Boolean())
     def set_contours_visible(self, state):
         """Set the contour visibility.
-        
+
         Parameters
         ----------
         state : {0}
             The desired visibility state.
         """
         self.call_action("contourConfig.setVisible", state)
-    
+
     def show_contours(self):
         """Show the contours."""
         self.set_contours_visible(True)
-        
+
     def hide_contours(self):
         """Hide the contours."""
         self.set_contours_visible(False)
-    
+
     # HISTOGRAM
-    
+
     @validate(Boolean())
     def use_cube_histogram(self, contours=False):
         """Use the cube histogram.
-        
+
         Parameters
         ----------
         contours : {0}
             Apply to the contours. By default this is applied to the raster image.
         """
         self.call_action(f"renderConfig.setUseCubeHistogram{'Contours' if contours else ''}", True)
-    
+
     @validate(Boolean())
     def use_channel_histogram(self, contours=False):
         """Use the channel histogram.
-        
+
         Parameters
         ----------
         contours : {0}
             Apply to the contours. By default this is applied to the raster image.
         """
         self.call_action(f"renderConfig.setUseCubeHistogram{'Contours' if contours else ''}", False)
-            
+
     @validate(Number(0, 100))
     def set_percentile_rank(self, rank):
         """Set the percentile rank.
-        
+
         Parameters
         ----------
         rank : {0}
             The percentile rank.
         """
         self.call_action("renderConfig.setPercentileRank", rank)
-    
+
     # CLOSE
-    
+
     def close(self):
         """Close this image."""
         self.session.call_action("closeFile", self._frame)

--- a/carta/protocol.py
+++ b/carta/protocol.py
@@ -10,6 +10,7 @@ import json
 from .token import BackendToken, ControllerToken
 from .util import logger, CartaBadRequest, CartaRequestFailed, CartaActionFailed, CartaBadResponse, CartaBadToken, CartaBadUrl, CartaEncoder, split_action_path
 
+
 class AuthType:
     BACKEND, CONTROLLER, NONE = 0, 1, 2
 

--- a/carta/protocol.py
+++ b/carta/protocol.py
@@ -16,9 +16,9 @@ class AuthType:
 
 class Protocol:
     """This object manages connections to a backend or controller instance, including any required authentication.
-    
+
     It should not be instantiated directly; it is created on demand when a :obj:`carta.session.Session` object is created using one of the convenience class methods provided.
-    
+
     Parameters
     ----------
     frontend_url : string
@@ -27,7 +27,7 @@ class Protocol:
         The security token used by the CARTA instance. May be omitted if the URL contains a token.
     debug_no_auth : boolean
         Disable authentication. This should be set if the backend has been started with the ``--debug_no_auth`` option. This is provided for debugging purposes only and should not be used under normal circumstances.
-        
+
     Raises
     ------
     CartaBadToken
@@ -38,11 +38,11 @@ class Protocol:
     ACTION_PATH = "/api/scripting/action"
     REFRESH_TOKEN_PATH = "/api/auth/login"
     SCRIPTING_TOKEN_PATH = "/api/auth/refresh"
-    
+
     def __init__(self, frontend_url, token=None, debug_no_auth=False):
         self.frontend_url = frontend_url
         self.base_url, token_from_url = self.split_token_from_url(frontend_url)
-        
+
         if debug_no_auth:
             self.auth = AuthType.NONE
         else:
@@ -63,13 +63,13 @@ class Protocol:
                 self.backend_token = token_from_url
             else:
                 raise CartaBadToken("Unrecognised token.")
-    
+
     @classmethod
     def request_refresh_token(cls, frontend_url, username, path=None):
         """Request a refresh token from a controller and optionally save it to a file.
-        
+
         This function must be run interactively. It securely prompts the user to enter a password.
-                
+
         Parameters
         ----------
         frontend_url : string
@@ -78,67 +78,67 @@ class Protocol:
             The username to use to authenticate with the controller.
         path : string, optional
             A path to a file where the refresh token should be saved.
-            
+
         Returns
         -------
         :obj:`carta.token.ControllerToken` object
             The token object created using the returned refresh token.
-            
+
         Raises
         ------
         CartaBadRequest
             If the request was invalid.
         CartaRequestFailed
             If the request failed.
-        CartaBadResponse    
+        CartaBadResponse
             If the response could not be decoded.
         """
         password = getpass.getpass(f"Please enter the CARTA password for user {username}: ")
-        
+
         payload = json.dumps({"username": username, "password": password})
         headers = {
             'Content-Type': 'application/json',
         }
-        
+
         try:
             response = requests.post(url=frontend_url.rstrip("/") + cls.REFRESH_TOKEN_PATH, headers=headers, data=payload)
         except requests.exceptions.RequestException as e:
             raise CartaBadRequest(f"Request for refresh token was invalid: {e}") from e
-            
+
         try:
             response_data = response.json()
         except simplejson.errors.JSONDecodeError as e:
             raise CartaBadResponse(f"Request for refresh token received a response which could not be decoded.\nError: {e}") from e
-        
+
         if response.status_code != 200:
             raise CartaRequestFailed(f"Request for refresh token failed with status code {response.status_code}: {response_data['message']}.")
-        
+
         token_string = None
-        
+
         for c in response.cookies:
             if c.name == "Refresh-Token":
                 token_string = c.value
                 break
-            
+
         if not token_string:
             raise CartaBadResponse("Request for refresh token did not receive a response with the expected cookie.")
 
         token = ControllerToken(token_string)
-        
+
         if path:
             token.save(path)
-            
+
         return token
 
     @classmethod
     def split_token_from_url(cls, url):
         """Extract a backend token from a frontend URL.
-        
+
         Parameters
         ----------
         url : string
             The URL of the frontend.
-            
+
         Returns
         -------
         string
@@ -150,24 +150,24 @@ class Protocol:
         ------
         CartaBadUrl
             If an invalid URL was provided.
-        
+
         """
         parsed_url = urllib.parse.urlparse(url)
-        
+
         if not (parsed_url.scheme and parsed_url.netloc):
             raise CartaBadUrl(f"Could not parse URL {url}.")
-        
+
         parsed_query = urllib.parse.parse_qs(parsed_url.query)
-        
+
         base_url = parsed_url._replace(query='').geturl().rstrip("/")
-        
+
         if "token" not in parsed_query:
             token = None
         else:
             token = BackendToken(parsed_query["token"][0])
-            
+
         return base_url, token
-    
+
     @property
     def domain(self):
         """The domain extracted from the frontend URL."""
@@ -177,29 +177,29 @@ class Protocol:
             if not self._domain:
                 raise CartaBadUrl(f"Could not parse domain from URL string '{self.frontend_url}'")
         return self._domain
-    
+
     @property
     def controller_auth(self):
         """Is controller authentication enabled?"""
         return self.auth == AuthType.CONTROLLER
-    
+
     @property
     def backend_auth(self):
         """Is backend authentication enabled?"""
         return self.auth == AuthType.BACKEND
-    
+
     @property
     def no_auth(self):
         """Is authentication disabled?"""
         return self.auth == AuthType.NONE
-    
+
     def cookie(self):
         """The refresh token in the form of a cookie."""
         return self.refresh_token.as_cookie(self.domain)
-    
+
     def check_refresh_token(self):
         """Check whether the refresh token has expired.
-        
+
         Raises
         ------
         CartaBadToken
@@ -210,43 +210,43 @@ class Protocol:
 
     def request_scripting_token(self):
         """Request a scripting token from the controller and cache it on this object.
-        
+
         Raises
         ------
         CartaBadRequest
             If the request was invalid.
         CartaRequestFailed
             If the request failed.
-        CartaBadResponse    
+        CartaBadResponse
             If the response could not be decoded.
         """
         self.check_refresh_token()
-        
+
         payload = json.dumps({"scripting": True})
-        
+
         headers = {
             'Content-Type': 'application/json',
             'Cookie': f'Refresh-Token={self.refresh_token.string}',
         }
-                
+
         try:
             response = requests.post(url=self.base_url + self.SCRIPTING_TOKEN_PATH, headers=headers, data=payload)
         except requests.exceptions.RequestException as e:
             raise CartaBadRequest(f"Request for scripting token was invalid: {e}") from e
-                    
+
         try:
             response_data = response.json()
         except simplejson.errors.JSONDecodeError as e:
             raise CartaBadResponse(f"Request for scripting token received a response which could not be decoded.\nError: {e}") from e
-                
+
         if response.status_code != 200:
             raise CartaRequestFailed(f"Request for scripting token failed with status code {response.status_code}: {response_data['message']}.")
-        
+
         self.scripting_token = ControllerToken(response_data["access_token"])
 
     def request_scripting_action(self, session_id, path, *args, **kwargs):
         """Call an action on the frontend through the backend's scripting interface.
-        
+
         Parameters
         ----------
         path : string
@@ -255,12 +255,12 @@ class Protocol:
             A variable-length list of parameters to pass to the action. :obj:`carta.util.Macro` objects may be used to refer to frontend objects which will be evaluated dynamically. This parameter list will be serialized into a JSON string with :obj:`carta.util.CartaEncoder`.
         **kwargs
             Arbitrary keyword arguments. At present only three are used: *async* (boolean) is passed to indicate that the request should return a response as soon as the action is called, without waiting for the action to complete. *response_expected* (boolean) indicates that the action should return a JSON object. This is set automatically if *return_path* is set. *return_path* specifies a subobject of the action's response which should be returned instead of the whole response. *timeout* (boolean) is the maximum time in seconds to wait for an action request to complete (the default is 10).
-        
+
         Returns
         -------
         None or an object
             If the action returns a JSON object, this method will return that response deserialized into a Python object.
-        
+
         Raises
         ------
         CartaBadRequest
@@ -269,15 +269,15 @@ class Protocol:
             If the backend could not send the request to the frontend.
         CartaActionFailed
             If the action failed.
-        CartaBadResponse    
+        CartaBadResponse
             If a request which was expected to have a JSON response did not have one, or if a JSON response could not be decoded.
         """
         timeout = kwargs.pop("timeout", 10)
         response_expected = kwargs.pop("response_expected", False)
         path, action = split_action_path(path)
-        
+
         logger.debug(f"Sending action request to backend; path: {path}; action: {action}; args: {args}, kwargs: {kwargs}")
-        
+
         request_kwargs = {
             "session_id": session_id,
             "path": path,
@@ -289,15 +289,15 @@ class Protocol:
         if "return_path" in kwargs:
             request_kwargs["return_path"] = kwargs["return_path"]
             response_expected = True
-        
+
         request_data = json.dumps(request_kwargs, cls=CartaEncoder)
-                
+
         carta_action_description = f"CARTA scripting action {path}.{action} called with parameters {args}"
-        
+
         headers = {
             'Content-Type': 'application/json',
         }
-        
+
         if self.controller_auth:
             if not self.scripting_token.valid():
                 self.check_refresh_token()
@@ -305,33 +305,33 @@ class Protocol:
             headers["Authorization"] = f"Bearer {self.scripting_token.string}"
         elif self.backend_auth:
             headers["Authorization"] = f"Bearer {self.backend_token.string}"
-        
+
         try:
             response = requests.post(url=self.base_url + self.ACTION_PATH, data=request_data, headers=headers, timeout=timeout)
         except requests.exceptions.RequestException as e:
             raise CartaBadRequest(f"{carta_action_description} failed: {e}") from e
-            
+
         known_errors = {
             400: "The backend could not parse the request.",
             403: "Could not authenticate.",
             404: f"No session with ID {session_id} could be found.",
             500: "An internal error occurred, or the client cancelled the request.",
         }
-                
+
         if response.status_code != 200:
             backend_message = known_errors.get(response.status_code, "Unknown error.")
             raise CartaRequestFailed(f"{carta_action_description} failed with status {response.status_code}. {backend_message}")
-                
+
         try:
             response_data = response.json()
         except simplejson.errors.JSONDecodeError as e:
             raise CartaBadResponse(f"{carta_action_description} received a response which could not be decoded.\nError: {e}") from e
-        
+
         logger.debug(f"Got response: {response_data}")
-        
+
         if not response_data['success']:
             raise CartaActionFailed(f"{carta_action_description} failed: {response_data.get('message', 'No error message received.')}")
-        
+
         if 'response' not in response_data:
             if response_expected:
                 raise CartaBadResponse(f"{carta_action_description} expected a response, but did not receive one.")

--- a/carta/protocol.py
+++ b/carta/protocol.py
@@ -4,7 +4,7 @@ import getpass
 
 import requests
 import simplejson
-import urllib
+import urllib.parse
 import json
 
 from .token import BackendToken, ControllerToken
@@ -15,6 +15,26 @@ class AuthType:
 
 
 class Protocol:
+    """This object manages connections to a backend or controller instance, including any required authentication.
+    
+    It should not be instantiated directly; it is created on demand when a :obj:`carta.session.Session` object is created using one of the convenience class methods provided.
+    
+    Parameters
+    ----------
+    frontend_url : string
+        The URL of the frontend.
+    token : :obj:`carta.token.Token`, optional
+        The security token used by the CARTA instance. May be omitted if the URL contains a token.
+    debug_no_auth : boolean
+        Disable authentication. This should be set if the backend has been started with the ``--debug_no_auth`` option. This is provided for debugging purposes only and should not be used under normal circumstances.
+        
+    Raises
+    ------
+    CartaBadToken
+        If an invalid token was provided.
+    CartaBadUrl
+        If an invalid URL was provided.
+    """
     ACTION_PATH = "/api/scripting/action"
     REFRESH_TOKEN_PATH = "/api/auth/login"
     SCRIPTING_TOKEN_PATH = "/api/auth/token"
@@ -46,6 +66,26 @@ class Protocol:
     
     @classmethod
     def request_refresh_token(cls, frontend_url, username, path=None):
+        """Request a refresh token from a controller and optionally save it to a file.
+        
+        This function must be run interactively. It securely prompts the user to enter a password.
+        
+        TODO: document exceptions
+        
+        Parameters
+        ----------
+        frontend_url : string
+            The URL of the frontend.
+        username : string
+            The username to use to authenticate with the controller.
+        path : string, optional
+            A path to a file where the refresh token should be saved.
+            
+        Returns
+        -------
+        :obj:`carta.token.ControllerToken` object
+            The token object created using the returned refresh token.
+        """
         # TODO test and add error handling
         password = getpass.getpass(f"Please enter the CARTA password for user {username}: ")
         payload = {"username": username, "password": password, "embedRefresh": True}
@@ -61,7 +101,28 @@ class Protocol:
 
     @classmethod
     def split_token_from_url(cls, url):
+        """Extract a backend token from a frontend URL.
+        
+        Parameters
+        ----------
+        url : string
+            The URL of the frontend.
+            
+        Returns
+        -------
+        string, :obj:`carta.token.BackendToken` object or None
+        
+        Raises
+        ------
+        CartaBadUrl
+            If an invalid URL was provided.
+        
+        """
         parsed_url = urllib.parse.urlparse(url)
+        
+        if not (parsed_url.scheme and parsed_url.netloc):
+            raise CartaBadUrl(f"Could not parse URL {url}.")
+        
         parsed_query = urllib.parse.parse_qs(parsed_url.query)
         
         base_url = parsed_url._replace(query='').geturl().rstrip("/")
@@ -75,6 +136,7 @@ class Protocol:
     
     @property
     def domain(self):
+        """The domain extracted from the frontend URL."""
         if not hasattr(self, "_domain"):
             parsed_url = urllib.parse.urlparse(self.frontend_url)
             self._domain = parsed_url.netloc
@@ -84,24 +146,39 @@ class Protocol:
     
     @property
     def controller_auth(self):
+        """Is controller authentication enabled?"""
         return self.auth == AuthType.CONTROLLER
     
     @property
     def backend_auth(self):
+        """Is backend authentication enabled?"""
         return self.auth == AuthType.BACKEND
     
     @property
     def no_auth(self):
+        """Is authentication disabled?"""
         return self.auth == AuthType.NONE
     
     def cookie(self):
+        """The refresh token in the form of a cookie."""
         return self.refresh_token.as_cookie(self.domain)
     
     def check_refresh_token(self):
+        """Check whether the refresh token has expired.
+        
+        Raises
+        ------
+        CartaBadToken
+            If the refresh token has expired.
+        """
         if not self.refresh_token.valid():
             raise CartaBadToken("Long-lived controller token has expired. Please use `Protocol.request_refresh_token` to log in and save a new token.")
 
     def request_scripting_token(self):
+        """Request a scripting token from the controller and cache it on this object.
+        
+        TODO: document exceptions.
+        """
         # TODO test and add error handling
         self.check_refresh_token()
         cookie = self.refresh_token.as_cookie()
@@ -109,6 +186,33 @@ class Protocol:
         self.scripting_token = ControllerToken(response["access_token"])
 
     def request_scripting_action(self, session_id, path, *args, **kwargs):
+        """Call an action on the frontend through the backend's scripting interface.
+        
+        Parameters
+        ----------
+        path : string
+            The full dot-separated path to a frontend action.
+        *args
+            A variable-length list of parameters to pass to the action. :obj:`carta.util.Macro` objects may be used to refer to frontend objects which will be evaluated dynamically. This parameter list will be serialized into a JSON string with :obj:`carta.util.CartaEncoder`.
+        **kwargs
+            Arbitrary keyword arguments. At present only three are used: *async* (boolean) is passed to indicate that the request should return a response as soon as the action is called, without waiting for the action to complete. *response_expected* (boolean) indicates that the action should return a JSON object. This is set automatically if *return_path* is set. *return_path* specifies a subobject of the action's response which should be returned instead of the whole response. *timeout* (boolean) is the maximum time in seconds to wait for an action request to complete (the default is 10).
+        
+        Returns
+        -------
+        None or an object
+            If the action returns a JSON object, this method will return that response deserialized into a Python object.
+        
+        Raises
+        ------
+        CartaBadRequest
+            If the request was invalid.
+        CartaRequestFailed
+            If the backend could not send the request to the frontend.
+        CartaActionFailed
+            If the action failed.
+        CartaBadResponse    
+            If a request which was expected to have a JSON response did not have one, or if a JSON response could not be decoded.
+        """
         timeout = kwargs.pop("timeout", 10)
         response_expected = kwargs.pop("response_expected", False)
         path, action = split_action_path(path)

--- a/carta/protocol.py
+++ b/carta/protocol.py
@@ -110,8 +110,11 @@ class Protocol:
             
         Returns
         -------
-        string, :obj:`carta.token.BackendToken` object or None
-        
+        string
+            The URL with the backend token removed.
+        :obj:`carta.token.BackendToken` object or None
+            The object representing the backend token.
+
         Raises
         ------
         CartaBadUrl

--- a/carta/protocol.py
+++ b/carta/protocol.py
@@ -294,8 +294,9 @@ class Protocol:
                 
         carta_action_description = f"CARTA scripting action {path}.{action} called with parameters {args}"
         
-        # TODO unclear why setting a content type explicitly here causes a read timeout but only with a controller
-        headers = {}
+        headers = {
+            'Content-Type': 'application/json',
+        }
         
         if self.controller_auth:
             if not self.scripting_token.valid():

--- a/carta/protocol.py
+++ b/carta/protocol.py
@@ -99,8 +99,8 @@ class Protocol:
     def request_scripting_token(self):
         # TODO test and add error handling
         self.check_refresh_token()
-        payload = {"token": self.refresh_token.string} # TODO what is this actually supposed to be???
-        response = requests.post(url=self.frontend_url + self.SCRIPTING_TOKEN_PATH, data=payload)
+        cookie = self.refresh_token.as_cookie()
+        response = requests.post(url=self.frontend_url + self.SCRIPTING_TOKEN_PATH, cookies={cookie["name"]: cookie["value"]})
         self.scripting_token = ControllerToken(response["token"]) # TODO what is this actually supposed to be???
 
     def request_scripting_action(self, session_id, path, *args, **kwargs):
@@ -110,12 +110,12 @@ class Protocol:
         logger.debug(f"Sending action request to backend; path: {path}; action: {action}; args: {args}, kwargs: {kwargs}")
         
         request_kwargs = {
-                "session_id": session_id,
-                "path": path,
-                "action": action,
-                "parameters": args,
-                "async": kwargs.get("async", False),
-            }
+            "session_id": session_id,
+            "path": path,
+            "action": action,
+            "parameters": args,
+            "async": kwargs.get("async", False),
+        }
 
         if "return_path" in kwargs:
             request_kwargs["return_path"] = kwargs["return_path"]

--- a/carta/protocol.py
+++ b/carta/protocol.py
@@ -16,8 +16,8 @@ class AuthType:
 
 class Protocol:
     ACTION_PATH = "/api/scripting/action"
-    REFRESH_TOKEN_PATH = "/api/auth/refresh"
-    SCRIPTING_TOKEN_PATH = "/api/auth/scripting"
+    REFRESH_TOKEN_PATH = "/api/auth/login"
+    SCRIPTING_TOKEN_PATH = "/api/auth/token"
     
     def __init__(self, frontend_url, token=None, debug_no_auth=False):
         self.frontend_url = frontend_url
@@ -48,11 +48,11 @@ class Protocol:
     def request_refresh_token(cls, frontend_url, username, path=None):
         # TODO test and add error handling
         password = getpass.getpass(f"Please enter the CARTA password for user {username}: ")
-        payload = {"username": username, "password": password}
+        payload = {"username": username, "password": password, "embedRefresh": True}
         
         response = requests.post(url=frontend_url.rstrip("/") + cls.REFRESH_TOKEN_PATH, data=payload)
         
-        token = ControllerToken(response["token"]) # TODO what is this actually supposed to be???
+        token = ControllerToken(response["refresh_token"])
         
         if path:
             token.save(path)
@@ -106,7 +106,7 @@ class Protocol:
         self.check_refresh_token()
         cookie = self.refresh_token.as_cookie()
         response = requests.post(url=self.base_url + self.SCRIPTING_TOKEN_PATH, cookies={cookie["name"]: cookie["value"]})
-        self.scripting_token = ControllerToken(response["token"]) # TODO what is this actually supposed to be???
+        self.scripting_token = ControllerToken(response["access_token"])
 
     def request_scripting_action(self, session_id, path, *args, **kwargs):
         timeout = kwargs.pop("timeout", 10)

--- a/carta/protocol.py
+++ b/carta/protocol.py
@@ -1,0 +1,155 @@
+"""This module provides classes and functions used to send HTTP requests to a backend or a controller."""
+
+import getpass
+
+import requests
+import urllib
+import json
+
+from .token import BackendToken, ControllerToken
+from .util import logger, CartaActionFailed, CartaBadResponse, CartaBadToken, CartaBadUrl, CartaEncoder, split_action_path
+
+class AuthType:
+    BACKEND, CONTROLLER, NONE = 0, 1, 2
+
+
+class Protocol:
+    ACTION_PATH = "/api/scripting/action"
+    REFRESH_TOKEN_PATH = "/api/auth/refresh"
+    SCRIPTING_TOKEN_PATH = "/api/auth/scripting"
+    
+    def __init__(self, frontend_url, token=None, debug_no_auth=False):
+        if debug_no_auth:
+            self.auth = AuthType.NONE
+        else:
+            if isinstance(token, ControllerToken):
+                if token.scripting:
+                    raise CartaBadToken("A long-lived controller refresh token was expected, but a short-lived controller scripting token was provided.")
+                
+                if not token.valid():
+                    raise CartaBadToken("Long-lived controller token has expired. Please use `Protocol.request_refresh_token` to log in and save a new token.")
+                
+                self.auth = AuthType.CONTROLLER
+                self.refresh_token = token
+                self.request_scripting_token()
+            elif isinstance(token, BackendToken):
+                self.auth = AuthType.BACKEND
+                self.backend_token = token
+            elif token is None:
+                try:
+                    frontend_url, token = self.split_token_from_url(frontend_url)
+                except CartaBadUrl:
+                    raise CartaBadToken("No token was provided, and no token could be parsed from the frontend URL.")
+                self.auth = AuthType.BACKEND
+                self.backend_token = token
+            else:
+                raise CartaBadToken("Unrecognised token.")
+        
+        self.frontend_url = frontend_url
+    
+    @classmethod
+    def request_refresh_token(cls, frontend_url, username, path=None):
+        # TODO test and add error handling
+        password = getpass.getpass(f"Please enter the CARTA password for user {username}: ")
+        payload = {"username": username, "password": password}
+        
+        response = requests.post(url=frontend_url + cls.REFRESH_TOKEN_PATH, data=payload)
+        
+        token = ControllerToken(response["token"]) # TODO what is this actually supposed to be???
+        
+        if path:
+            token.save(path)
+            
+        return token
+
+    @classmethod
+    def split_token_from_url(cls, url):
+        parsed_url = urllib.parse.urlparse(url)
+        parsed_query = urllib.parse.parse_qs(parsed_url.query)
+        
+        if "token" not in parsed_query:
+            raise CartaBadUrl(f"Could not parse URL and token from URL string '{url}'")
+        return parsed_url._replace(query='').geturl(), BackendToken(parsed_query["token"][0])
+    
+    @property
+    def domain(self):
+        if not hasattr(self, "_domain"):
+            parsed_url = urllib.parse.urlparse(self.frontend_url)
+            self._domain = parsed_url.netloc
+            if not self._domain:
+                raise CartaBadUrl(f"Could not parse domain from URL string '{self.frontend_url}'")
+        return self._domain
+    
+    @property
+    def controller_auth(self):
+        return self.auth == AuthType.CONTROLLER
+    
+    @property
+    def backend_auth(self):
+        return self.auth == AuthType.BACKEND
+    
+    @property
+    def no_auth(self):
+        return self.auth == AuthType.NONE
+    
+    def cookie(self):
+        return self.refresh_token.as_cookie(self.domain)
+
+    def request_scripting_token(self):
+        # TODO test and add error handling
+        payload = {"token": self.refresh_token.string} # TODO what is this actually supposed to be???
+        response = requests.post(url=self.frontend_url + self.SCRIPTING_TOKEN_PATH, data=payload)
+        self.scripting_token = ControllerToken(response["token"]) # TODO what is this actually supposed to be???
+
+    def request_scripting_action(self, session_id, path, *args, **kwargs):
+        response_expected = kwargs.pop("response_expected", False)
+        path, action = split_action_path(path)
+        
+        logger.debug(f"Sending action request to backend; path: {path}; action: {action}; args: {args}, kwargs: {kwargs}")
+        
+        request_kwargs = {
+                "session_id": session_id,
+                "path": path,
+                "action": action,
+                "parameters": args,
+                "async": kwargs.get("async", False),
+            }
+
+        if "return_path" in kwargs:
+            request_kwargs["return_path"] = kwargs["return_path"]
+        
+        # TODO does this work? do we need to convert to bytes explicitly?
+        request_data = json.dumps(request_kwargs, cls=CartaEncoder)
+        
+        carta_action_description = f"CARTA scripting action {path}.{action} called with parameters {args}"
+        
+        
+        headers = {}
+        if self.controller_auth:
+            if not self.scripting_token.valid():
+                self.request_scripting_token()
+            headers["Authorization"] = f"Bearer: {self.scripting_token.string}"
+        elif self.backend_auth:
+            headers["Authorization"] = f"Bearer: {self.backend_token.string}"
+        
+        try:
+            response = requests.post(url=self.frontend_url + self.ACTION_PATH, data=request_data, headers=headers)
+        except requests.exceptions.RequestException as e:
+            raise CartaActionFailed(f"{carta_action_description} failed: {e.details()}") from e
+        
+        try:
+            response_data = response.json()
+        except json.decoder.JSONDecodeError as e:
+            raise CartaBadResponse(f"{carta_action_description} received a response which could not be decoded.\nError: {e}") from e
+        
+        logger.debug(f"Got success status: {response_data.success}; message: {response_data.message}; response: {response_data.response}")
+        
+        if not response_data.success:
+            raise CartaActionFailed(f"{carta_action_description} failed: {response_data.message}")
+        
+        if response_data.response == '':
+            if response_expected:
+                raise CartaBadResponse(f"{carta_action_description} expected a response, but did not receive one.")
+            return None
+
+        return response_data

--- a/carta/session.py
+++ b/carta/session.py
@@ -34,8 +34,11 @@ class Session:
         The browser object associated with this session. This is created automatically when a new session is created with :obj:`carta.session.Session.create` or :obj:`carta.session.Session.start_and_create`.
     backend : :obj:`carta.backend.Backend`
         The backend object associated with this session. This is created automatically when a new session is created with :obj:`carta.session.Session.start_and_create`.
-    debug_no_auth : boolean
-        Disable authentication. This should be set if the backend has been started with the ``--debug_no_auth`` option. This is provided for debugging purposes only and should not be used under normal circumstances.
+
+    Attributes
+    ----------
+    session_id : integer
+        The ID of the CARTA frontend session associated with this object.
     """
 
     def __init__(self, session_id, protocol, browser=None, backend=None):

--- a/carta/session.py
+++ b/carta/session.py
@@ -16,13 +16,13 @@ from .validation import validate, String, Number, Color, Constant, Boolean, None
 
 class Session:
     """This object corresponds to a CARTA frontend session.
-    
+
     This class provides the core generic method for calling actions on the frontend (through the backend), as well as convenience methods which wrap this generic method and provide a more intuitive and user-friendly interface to frontend functionality associated with the session as a whole.
-    
+
     This class should not be instantiated directly. Three class methods are provided for creating different types of sessions with all the appropriate parameters set: :obj:`carta.session.Session.interact` for interacting with an existing CARTA session open in the user's browser, :obj:`carta.session.Session.create` for creating a new CARTA session in a headless browser by connecting to an existing CARTA backend or controller instance, and :obj:`carta.session.Session.start_and_create` for starting a new backend instance and then connecting to it to create a new session in a headless browser.
-    
+
     The session object can be used to create image objects, which provide analogous convenience methods for functionality associated with individual images.
-    
+
     Parameters
     ----------
     session_id : integer
@@ -41,17 +41,17 @@ class Session:
         self._protocol = protocol
         self._browser = browser
         self._backend = backend
-        
+
         # This is a local point of reference for paths, and may not be in sync with the frontend's starting directory
         self._pwd = None
-        
+
     def __del__(self):
         self.close()
-    
+
     @classmethod
     def interact(cls, frontend_url, session_id, token=None, debug_no_auth=False):
         """Interact with an existing CARTA frontend session.
-        
+
         Parameters
         ----------
         frontend_url : string
@@ -62,12 +62,12 @@ class Session:
             The security token used by the CARTA instance. You may omit this if the URL contains a token.
         debug_no_auth : boolean, optional
             Disable authentication. Set this if the backend has been started with the ``--debug_no_auth`` option. This is provided for debugging purposes only and should not be used under normal circumstances.
-            
+
         Returns
         -------
         :obj:`carta.session.Session`
             A session object associated with the frontend session provided.
-            
+
         Raises
         ------
         CartaBadToken
@@ -78,11 +78,11 @@ class Session:
             If the session object could not be created.
         """
         return cls(session_id, Protocol(frontend_url, token, debug_no_auth=debug_no_auth))
-    
+
     @classmethod
     def create(cls, browser, frontend_url, token=None, timeout=10, debug_no_auth=False):
         """Connect to an existing CARTA backend or CARTA controller instance and create a new session.
-        
+
         Parameters
         ----------
         browser : :obj:`carta.browser.Browser`
@@ -95,12 +95,12 @@ class Session:
             The number of seconds to spend retrying parsing connection information from the frontend (default: 10).
         debug_no_auth : boolean, optional
             Disable authentication. Set this if the backend has been started with the ``--debug_no_auth`` option. This is provided for debugging purposes only and should not be used under normal circumstances.
-            
+
         Returns
         -------
         :obj:`carta.session.Session`
             A session object connected to a new frontend session running in the browser provided.
-            
+
         Raises
         ------
         CartaBadToken
@@ -111,11 +111,11 @@ class Session:
             If the session object could not be created.
         """
         return browser.new_session_from_url(frontend_url, token, backend=None, timeout=timeout, debug_no_auth=debug_no_auth)
-    
+
     @classmethod
     def start_and_create(cls, browser, executable_path="carta", remote_host=None, params=tuple(), timeout=10, token=None):
         """Start a new CARTA backend instance and create a new session. This method cannot be used with a CARTA controller instance (which already starts and stops backend instances for the user on demand).
-        
+
         Parameters
         ----------
         browser : :obj:`carta.browser.Browser`
@@ -130,12 +130,12 @@ class Session:
             The number of seconds to spend parsing the frontend for connection information. 10 seconds by default.
         token : :obj:`carta.token.Token`, optional
             The security token to use. Parsed from the backend output by default.
-            
+
         Returns
         -------
         :obj:`carta.session.Session`
             A session object connected to a new frontend session running in the browser provided.
-            
+
         Raises
         ------
         CartaBadToken
@@ -146,15 +146,15 @@ class Session:
             If the session object could not be created.
         """
         return browser.new_session_with_backend(executable_path, remote_host, params, timeout, token)
-        
+
     def __repr__(self):
         return f"Session(session_id={self.session_id}, uri={self._protocol.frontend_url})"
-        
+
     def call_action(self, path, *args, **kwargs):
         """Call an action on the frontend through the backend's scripting interface.
-        
+
         This method is the core of the session class, and provides a generic interface for calling any action on the frontend. This is exposed as a public method to give developers the option of writing experimental functionality; wherever possible script writers should instead use the more user-friendly methods on the session and image objects which wrap this method.
-        
+
         Parameters
         ----------
         path : string
@@ -163,12 +163,12 @@ class Session:
             A variable-length list of parameters to pass to the action. :obj:`carta.util.Macro` objects may be used to refer to frontend objects which will be evaluated dynamically. This parameter list will be serialized into a JSON string with :obj:`carta.util.CartaEncoder`.
         **kwargs
             Arbitrary keyword arguments. At present only three are used: *async* (boolean) is passed to indicate that the request should return a response as soon as the action is called, without waiting for the action to complete. *response_expected* (boolean) indicates that the action should return a JSON object. This is set automatically if *return_path* is set. *return_path* specifies a subobject of the action's response which should be returned instead of the whole response. *timeout* (boolean) is the maximum time in seconds to wait for an action request to complete (the default is 10).
-        
+
         Returns
         -------
         None or an object
             If the action returns a JSON object, this method will return that response deserialized into a Python object.
-        
+
         Raises
         ------
         CartaBadRequest
@@ -177,7 +177,7 @@ class Session:
             If the backend could not send the request to the frontend.
         CartaActionFailed
             If the action failed.
-        CartaBadResponse    
+        CartaBadResponse
             If a request which was expected to have a JSON response did not have one, or if a JSON response could not be decoded.
         """
         try:
@@ -188,14 +188,14 @@ class Session:
 
     def get_value(self, path):
         """Get the value of an attribute from a frontend store.
-        
+
         Like the :obj:`carta.session.Session.call_action` method, this is exposed in the public API but is not intended to be used directly under normal circumstances.
-        
+
         Parameters
         ----------
         path : string
             The full path to the attribute.
-        
+
         Returns
         -------
         object
@@ -204,17 +204,17 @@ class Session:
         path, parameter = split_action_path(path)
         macro = Macro(path, parameter)
         return self.call_action("fetchParameter", macro, response_expected=True)
-    
+
     # FILE BROWSING
-    
+
     def resolve_file_path(self, path):
         """Convert a file path to an absolute path.
-        
+
         Parameters
         ----------
         path : string
             The file path, which may be absolute or relative to the current directory.
-            
+
         Returns
         -------
         string
@@ -224,28 +224,28 @@ class Session:
             return path
         else:
             return f"{self.pwd()}/{path}"
-    
+
     def pwd(self):
         """The current directory. This is a local property of the wrapper, and may not be in sync with the frontend's saved starting directory, which is changed whenever a file is opened to the file's parent directory.
-        
+
         Returns
         -------
         string
-            The session's current directory. 
+            The session's current directory.
         """
         if self._pwd is None:
             self.call_action("fileBrowserStore.getFileList", Macro("fileBrowserStore", "startingDirectory"))
             directory = self.get_value("fileBrowserStore.fileList.directory")
             self._pwd = f"/{directory}"
         return self._pwd
-    
+
     def ls(self):
         """The current directory listing.
-        
+
         Returns
         -------
         list
-            The list of files and subdirectories in the session's locally stored current directory. 
+            The list of files and subdirectories in the session's locally stored current directory.
         """
         self.call_action("fileBrowserStore.getFileList", self.pwd())
         file_list = self.get_value("fileBrowserStore.fileList")
@@ -255,46 +255,46 @@ class Session:
         if "subdirectories" in file_list:
             items.extend([f"{d['name']}/" for d in file_list["subdirectories"]])
         return sorted(items)
-    
+
     def cd(self, path):
         """Change the current directory used by the wrapper.
-        
+
         TODO: .. is not supported, but it can be now that we have made this value independent of the frontend.
-        
+
         This does not affect the starting directory saved by the frontend. To change that directory, use :obj:`carta.session.Session.set_starting_directory`.
-        
+
         Parameters
         ----------
         path : string
             The path to the new directory, which may be relative to the current directory or absolute (relative to the CARTA backend root).
         """
         self._pwd = self.resolve_file_path(path)
-        
+
     def set_starting_directory(self, path):
         """Change the starting directory of the frontend.
-        
-        This is particularly useful for interactive sessions. If a new session object reconnects to an existing frontend session, this method allows the current directory in the frontend session to be reset to a known state. This ensures that any paths used in the script continue to work even if the current directory in the frontend changed during a previous execution. 
-        
+
+        This is particularly useful for interactive sessions. If a new session object reconnects to an existing frontend session, this method allows the current directory in the frontend session to be reset to a known state. This ensures that any paths used in the script continue to work even if the current directory in the frontend changed during a previous execution.
+
         It should not be necessary to use this method in non-interactive scripts which do not reuse frontend sessions.
-        
+
         This does not affect the current directory used by the wrapper. To change that directory, use :obj:`carta.session.Session.cd`.
-        
+
         This method must be called before any methods that use the locally saved path.
-        
+
         Parameters
         ----------
         path : string
             The path to the new directory, which must be absolute (relative to the CARTA backend root).
-        
+
         """
         self.call_action("fileBrowserStore.saveStartingDirectory", path)
-    
+
     # IMAGES
 
     @validate(String(), String("\d*"))
     def open_image(self, path, hdu=""):
         """Open a new image, replacing any existing images.
-        
+
         Parameters
         ----------
         path : {0}
@@ -307,7 +307,7 @@ class Session:
     @validate(String(), String("\d*"))
     def append_image(self, path, hdu=""):
         """Append a new image, keeping any existing images.
-        
+
         Parameters
         ----------
         path : {0}
@@ -319,16 +319,16 @@ class Session:
 
     def image_list(self):
         """Return the list of currently open images.
-        
+
         Returns
         -------
         list of :obj:`carta.image.Image` objects.
         """
         return Image.from_list(self, self.get_value("frameNames"))
-    
+
     def active_frame(self):
         """Return the currently active image.
-        
+
         Returns
         -------
         :obj:`carta.image.Image`
@@ -338,20 +338,20 @@ class Session:
         image_id = frame_info["fileId"]
         file_name = frame_info["fileInfo"]["name"]
         return Image(self, image_id, file_name)
-    
+
     def clear_spatial_reference(self):
         """Clear the spatial reference."""
         self.call_action("clearSpatialReference")
-    
+
     def clear_spectral_reference(self):
         """Clear the spectral reference."""
         self.call_action("clearSpectralReference")
-        
+
     # CANVAS AND OVERLAY
     @validate(Number(), Number())
     def set_view_area(self, width, height):
         """Set the dimensions of the view area.
-                
+
         Parameters
         ----------
         width : {0}
@@ -360,33 +360,33 @@ class Session:
             The new height, in pixels, divided by the device pixel ratio.
         """
         self.call_action("overlayStore.setViewDimension", width, height)
-    
+
     @validate(Constant(CoordinateSystem))
     def set_coordinate_system(self, system=CoordinateSystem.AUTO):
         """Set the coordinate system.
-        
+
         Parameters
         ----------
         system : {0}
             The coordinate system.
         """
         self.call_action("overlayStore.global.setSystem", system)
-        
+
     @validate(Constant(LabelType))
     def set_label_type(self, label_type):
         """Set the label type.
-        
+
         Parameters
         ----------
         label_type : {0}
             The label type.
         """
         self.call_action("overlayStore.global.setLabelType", label_type)
-    
+
     @validate(NoneOr(String()), NoneOr(String()), NoneOr(String()))
     def set_text(self, title=None, label_x=None, label_y=None):
         """Set custom title and/or the axis label text.
-        
+
         Parameters
         ----------
         title : {0}
@@ -405,18 +405,18 @@ class Session:
             self.call_action("overlayStore.labels.setCustomLabelX", label_y)
         if label_x is not None or label_y is not None:
             self.call_action("overlayStore.labels.setCustomText", True)
-    
+
     def clear_text(self):
         """Clear all custom title and axis text."""
         self.call_action("overlayStore.title.setCustomText", False)
         self.call_action("overlayStore.labels.setCustomText", False)
-    
+
     @validate(OneOf(Overlay.TITLE, Overlay.NUMBERS, Overlay.LABELS), NoneOr(String()), NoneOr(Number()))
     def set_font(self, component, font=None, font_size=None):
         """Set the font and/or font size of an overlay component.
-        
+
         TODO: can we get the allowed font names from somewhere?
-        
+
         Parameters
         ----------
         component : {0}
@@ -430,11 +430,11 @@ class Session:
             self.call_action(f"overlayStore.{component}.setFont", font)
         if font_size is not None:
             self.call_action(f"overlayStore.{component}.setFontSize", font_size)
-        
+
     @validate(NoneOr(Constant(BeamType)), NoneOr(Number()), NoneOr(Number()), NoneOr(Number()))
     def set_beam(self, beam_type=None, width=None, shift_x=None, shift_y=None):
         """Set the beam properties.
-        
+
         Parameters
         ----------
         beam_type : {0}
@@ -454,11 +454,11 @@ class Session:
             self.call_action(f"overlayStore.{Overlay.BEAM}.setShiftX", shift_x)
         if shift_y is not None:
             self.call_action(f"overlayStore.{Overlay.BEAM}.setShiftY", shift_y)
-        
+
     @validate(Constant(PaletteColor), Constant(Overlay))
     def set_color(self, color, component=Overlay.GLOBAL):
         """Set the custom color on an overlay component, or the global color.
-                
+
         Parameters
         ----------
         color : {0}
@@ -469,11 +469,11 @@ class Session:
         self.call_action(f"overlayStore.{component}.setColor", color)
         if component not in (Overlay.GLOBAL, Overlay.BEAM):
             self.call_action(f"overlayStore.{component}.setCustomColor", True)
-    
-    @validate(Constant(Overlay)) 
+
+    @validate(Constant(Overlay))
     def clear_color(self, component):
         """Clear the custom color from an overlay component.
-        
+
         Parameters
         ----------
         component : {0}
@@ -481,13 +481,13 @@ class Session:
         """
         if component != Overlay.GLOBAL:
             self.call_action(f"overlayStore.{component}.setCustomColor", False)
- 
+
     @validate(Constant(Overlay), Boolean())
     def set_visible(self, component, visible):
         """Set the visibility of an overlay component.
-        
+
         Ticks cannot be shown or hidden in AST.
-        
+
         Parameters
         ----------
         component : {0}
@@ -501,97 +501,97 @@ class Session:
 
         if component != Overlay.GLOBAL:
             self.call_action(f"overlayStore.{component}.setVisible", visible)
-    
-    @validate(Constant(Overlay)) 
+
+    @validate(Constant(Overlay))
     def show(self, component):
         """Show an overlay component.
-        
+
         Parameters
         ----------
         component : {0}
             The overlay component.
         """
         self.set_visible(component, True)
- 
-    @validate(Constant(Overlay)) 
+
+    @validate(Constant(Overlay))
     def hide(self, component):
         """Hide an overlay component.
-        
+
         Parameters
         ----------
         component : {0}
             The overlay component.
         """
         self.set_visible(component, False)
-            
+
     def toggle_labels(self):
         """Toggle the overlay labels."""
         self.call_action("overlayStore.toggleLabels")
-    
+
     # PROFILES (TODO)
-    
-    @validate(Number(), Number()) 
+
+    @validate(Number(), Number())
     def set_cursor(self, x, y):
         """Set the curson position.
-        
+
         TODO: this is a precursor to makinf z-profiles available, but currently the relevant functionality is not exposed by the frontend.
-        
+
         Parameters
         ----------
         x : {0}
             The X position.
         y : {1}
             The Y position.
-        
+
         """
         self.active_frame().call_action("regionSet.regions[0].setControlPoint", 0, [x, y])
-    
+
     # SAVE IMAGE
-    
+
     @validate(NoneOr(Color()))
     def rendered_view_url(self, background_color=None):
         """Get a data URL of the rendered active image.
-        
+
         Parameters
         ----------
         background_color : {0}
             The background color. By default the background will be transparent.
-            
+
         Returns
         -------
         string
             A data URL for the rendered image in PNG format, base64-encoded.
-        
+
         """
         self.call_action("waitForImageData")
         args = ["getImageDataUrl"]
         if background_color:
             args.append(background_color)
         return self.call_action(*args, response_expected=True)
-    
+
     @validate(NoneOr(Color()))
     def rendered_view_data(self, background_color=None):
         """Get the decoded data of the rendered active image.
-        
+
         Parameters
         ----------
         background_color : {0}
             The background color. By default the background will be transparent.
-            
+
         Returns
         -------
         bytes
             The decoded PNG image data.
-        
+
         """
         uri = self.rendered_view_url(background_color)
         data = uri.split(",")[1]
         return base64.b64decode(data)
-    
+
     @validate(String(), NoneOr(Color()))
     def save_rendered_view(self, file_name, background_color=None):
         """Save the decoded data of the rendered active image to a file.
-        
+
         Parameters
         ----------
         file_name : {0}
@@ -601,17 +601,17 @@ class Session:
         """
         with open(file_name, 'wb') as f:
             f.write(self.rendered_view_data(background_color))
-            
+
     def close(self):
         """Close the browser session and stop the backend process, if applicable.
-        
+
         If this session was newly created in a headless browser, close the browser session. If a new backend process was also started, stop the backend process.
-        
+
         If this session is interacting with an existing external browser session, this method has no effect.
         """
-        
+
         if self._browser is not None:
             self._browser.close()
-            
+
         if self._backend is not None:
             self._backend.stop()

--- a/carta/session.py
+++ b/carta/session.py
@@ -1,41 +1,38 @@
 """
-This is the main module of the CARTA Python wrapper. It comprises a session class which represents a CARTA frontend session, and an image class which represents a single image open in the session.
+This is the main module of the CARTA Python wrapper. It contains a session class which represents a CARTA frontend session.
 
-The user can interact with an existing CARTA session open in their browser by creating a session object using the :obj:`carta.client.Session.interact` classmethod.
+The user can interact with an existing CARTA session open in their browser by creating a session object using the :obj:`carta.session.Session.interact` classmethod.
 
-Alternatively, the user can create a new session which runs in a headless browser controlled by the wrapper. The user can connect to an existing CARTA backend instance (using the :obj:`carta.client.Session.connect` classmethod), or first start a new CARTA backend instance which is also controlled by the wrapper (using the :obj:`carta.client.Session.new` classmethod). The backend can be started either on the local host or on a remote host which the user can access with passwordless SSH.
-
-Image objects should not be instantiated directly, and should only be created through methods on the session object.
+Alternatively, the user can create a new session which runs in a headless browser controlled by the wrapper. The user can connect to an existing CARTA backend instance (using the :obj:`carta.session.Session.connect` classmethod), or first start a new CARTA backend instance which is also controlled by the wrapper (using the :obj:`carta.session.Session.new` classmethod). The backend can be started either on the local host or on a remote host which the user can access with passwordless SSH.
 """
 
-import posixpath
 import base64
 
-from .constants import Colormap, Scaling, CoordinateSystem, LabelType, BeamType, PaletteColor, Overlay, SmoothingMode, ContourDashMode
+from .image import Image
+from .constants import CoordinateSystem, LabelType, BeamType, PaletteColor, Overlay
 from .protocol import Protocol
-from .util import logger, Macro, cached, split_action_path, CartaScriptingException
-from .validation import validate, String, Number, Color, Constant, Boolean, NoneOr, IterableOf, OneOf, Evaluate, Attr
+from .util import logger, Macro, split_action_path, CartaScriptingException
+from .validation import validate, String, Number, Color, Constant, Boolean, NoneOr, OneOf
 
-# TODO split Session and Image into two files!
 class Session:
     """This object corresponds to a CARTA frontend session.
     
     This class provides the core generic method for calling actions on the frontend (through the backend), as well as convenience methods which wrap this generic method and provide a more intuitive and user-friendly interface to frontend functionality associated with the session as a whole.
     
-    This class should not be instantiated directly. Three class methods are provided for creating different types of sessions with all the appropriate parameters set: :obj:`carta.client.Session.interact` for interacting with an existing CARTA session open in the user's browser, :obj:`carta.client.Session.create` for creating a new CARTA session in a headless browser by connecting to an existing CARTA backend or controller instance, and :obj:`carta.client.Session.start_and_create` for starting a new backend instance and then connecting to it to create a new session in a headless browser.
+    This class should not be instantiated directly. Three class methods are provided for creating different types of sessions with all the appropriate parameters set: :obj:`carta.session.Session.interact` for interacting with an existing CARTA session open in the user's browser, :obj:`carta.session.Session.create` for creating a new CARTA session in a headless browser by connecting to an existing CARTA backend or controller instance, and :obj:`carta.session.Session.start_and_create` for starting a new backend instance and then connecting to it to create a new session in a headless browser.
     
     The session object can be used to create image objects, which provide analogous convenience methods for functionality associated with individual images.
     
     Parameters
     ----------
     session_id : integer
-        The ID of the CARTA frontend session associated with this object. This is set automatically when a new session is created with :obj:`carta.client.Session.create` or :obj:`carta.client.Session.start_and_create`.
+        The ID of the CARTA frontend session associated with this object. This is set automatically when a new session is created with :obj:`carta.session.Session.create` or :obj:`carta.session.Session.start_and_create`.
     protocol : :obj:`carta.protocol.Protocol`
         The protocol object which handles HTTP communication with the CARTA scripting API. This is created automatically when a new session is created with one of the three class methods for creating sessions.
     browser : :obj:`carta.browser.Browser`
-        The browser object associated with this session. This is created automatically when a new session is created with :obj:`carta.client.Session.create` or :obj:`carta.client.Session.start_and_create`.
+        The browser object associated with this session. This is created automatically when a new session is created with :obj:`carta.session.Session.create` or :obj:`carta.session.Session.start_and_create`.
     backend : :obj:`carta.browser.Backend`
-        The backend object associated with this session. This is created automatically when a new session is created with :obj:`carta.client.Session.start_and_create`.
+        The backend object associated with this session. This is created automatically when a new session is created with :obj:`carta.session.Session.start_and_create`.
     debug_no_auth : boolean
         This should be set if the backend has been started with the ``--debug_no_auth`` option. This is provided for debugging purposes only and should not be used under normal circumstances.
     """
@@ -68,7 +65,7 @@ class Session:
             
         Returns
         -------
-        :obj:`carta.client.Session`
+        :obj:`carta.session.Session`
             A session object associated with the frontend session provided.
             
         Raises
@@ -101,7 +98,7 @@ class Session:
             
         Returns
         -------
-        :obj:`carta.client.Session`
+        :obj:`carta.session.Session`
             A session object connected to a new frontend session running in the browser provided.
             
         Raises
@@ -136,7 +133,7 @@ class Session:
             
         Returns
         -------
-        :obj:`carta.client.Session`
+        :obj:`carta.session.Session`
             A session object connected to a new frontend session running in the browser provided.
             
         Raises
@@ -188,7 +185,7 @@ class Session:
     def get_value(self, path):
         """Get the value of an attribute from a frontend store.
         
-        Like the :obj:`carta.client.Session.call_action` method, this is exposed in the public API but is not intended to be used directly under normal circumstances.
+        Like the :obj:`carta.session.Session.call_action` method, this is exposed in the public API but is not intended to be used directly under normal circumstances.
         
         Parameters
         ----------
@@ -260,7 +257,7 @@ class Session:
         
         TODO: .. is not supported, but it can be now that we have made this value independent of the frontend.
         
-        This does not affect the starting directory saved by the frontend. To change that directory, use :obj:`carta.client.session.set_starting_directory`.
+        This does not affect the starting directory saved by the frontend. To change that directory, use :obj:`carta.session.Session.set_starting_directory`.
         
         Parameters
         ----------
@@ -276,7 +273,7 @@ class Session:
         
         It should not be necessary to use this method in non-interactive scripts which do not reuse frontend sessions.
         
-        This does not affect the current directory used by the wrapper. To change that directory, use :obj:`carta.client.session.cd`.
+        This does not affect the current directory used by the wrapper. To change that directory, use :obj:`carta.session.Session.cd`.
         
         This method must be called before any methods that use the locally saved path.
         
@@ -321,7 +318,7 @@ class Session:
         
         Returns
         -------
-        list of :obj:`carta.client.Image` objects.
+        list of :obj:`carta.image.Image` objects.
         """
         return Image.from_list(self, self.get_value("frameNames"))
     
@@ -330,7 +327,7 @@ class Session:
         
         Returns
         -------
-        :obj:`carta.client.Image`
+        :obj:`carta.image.Image`
             The currently active image.
         """
         frame_info = self.get_value("activeFrame.frameInfo")
@@ -614,458 +611,3 @@ class Session:
             
         if self._backend is not None:
             self._backend.stop()
-
-
-class Image:
-    """This object corresponds to an image open in a CARTA frontend session.
-    
-    This class should not be instantiated directly. Instead, use the session object's methods for opening new images or retrieving existing images.
-    
-    Parameters
-    ----------
-    session : :obj:`carta.client.Session`
-        The session object associated with this image.
-    image_id : integer
-        The ID identifying this image within the session. This is a unique number which is not reused, not the index of the image within the list of currently open images.
-    file_name : string
-        The file name of the image. This is not a full path.
-    
-    Attributes
-    ----------
-    session : :obj:`carta.client.Session`
-        The session object associated with this image.
-    image_id : integer
-        The ID identifying this image within the session.
-    file_name : string
-        The file name of the image.
-    
-    """
-    def __init__(self, session, image_id, file_name):
-        self.session = session
-        self.image_id = image_id
-        self.file_name = file_name
-        
-        self._base_path = f"frameMap[{image_id}]"
-        self._frame = Macro("", self._base_path)
-    
-    @classmethod
-    def new(cls, session, path, hdu, append):
-        """Open or append a new image in the session and return an image object associated with it.
-        
-        This method should not be used directly. It is wrapped by :obj:`carta.client.Session.open_image` and :obj:`carta.client.Session.append_image`.
-        
-        Parameters
-        ----------
-        session : :obj:`carta.client.Session`
-            The session object.
-        path : string
-            The path to the image file, either relative to the session's current directory or an absolute path relative to the CARTA backend's root directory.
-        hdu : string
-            The HDU to open.
-        append : boolean
-            Whether the image should be appended. By default it is not, and all other open images are closed.
-        
-        Returns
-        -------
-        :obj:`carta.client.Image`
-            A new image object.
-        """
-        path = session.resolve_file_path(path)
-        directory, file_name = posixpath.split(path)
-        image_id = session.call_action("appendFile" if append else "openFile", directory, file_name, hdu, return_path="frameInfo.fileId")
-        
-        return cls(session, image_id, file_name)
-    
-    @classmethod
-    def from_list(cls, session, image_list):
-        """Create a list of image objects from a list of open images retrieved from the frontend.
-        
-        This method should not be used directly. It is wrapped by :obj:`carta.client.Session.image_list`.
-        
-        Parameters
-        ----------
-        session : :obj:`carta.client.Session`
-            The session object.
-        image_list : list of dicts
-            The JSON object representing frame names retrieved from the frontend.
-            
-        Returns
-        -------
-        list of :obj:`carta.client.Image`
-            A list of new image objects.
-        """
-        return [cls(session, f["value"], f["label"].split(":")[1].strip()) for f in image_list]
-        
-    def __repr__(self):
-        return f"{self.session.session_id}:{self.image_id}:{self.file_name}"
-    
-    def call_action(self, path, *args, **kwargs):
-        """Convenience wrapper for the session object's generic action method.
-        
-        This method calls :obj:`carta.client.Session.call_action` after prepending this image's base path to the path parameter.
-        
-        Parameters
-        ----------
-        path : string
-            The path to an action relative to this image's frame store.
-        *args
-            A variable-length list of parameters. These are passed unmodified to the session method.
-        **kwargs
-            Arbitrary keyword parameters. These are passed unmodified to the session method.
-        
-        Returns
-        -------
-            object or None
-                The unmodified return value of the session method.
-        """
-        return self.session.call_action(f"{self._base_path}.{path}", *args, **kwargs)
-    
-    def get_value(self, path):
-        """Convenience wrapper for the session object's generic method for retrieving attribute values.
-        
-        This method calls :obj:`carta.client.Session.get_value` after prepending this image's base path to the path parameter.
-        
-        Parameters
-        ----------
-        path : string
-            The path to an attribute relative to this image's frame store.
-        
-        Returns
-        -------
-            object
-                The unmodified return value of the session method.
-        """
-        return self.session.get_value(f"{self._base_path}.{path}")
-    
-    # METADATA
-    
-    @property
-    @cached
-    def directory(self):
-        """The path to the directory containing the image."""
-        return self.get_value("frameInfo.directory")
-    
-    @property
-    @cached
-    def header(self):
-        """The header of the image."""
-        return self.get_value("frameInfo.fileInfoExtended.headerEntries")
-    
-    @property
-    @cached
-    def shape(self):
-        """The shape of the image."""
-        return list(reversed([self.width, self.height, self.depth, self.stokes][:self.ndim]))
-    
-    @property
-    @cached
-    def width(self):
-        """The width of the image."""
-        return self.get_value("frameInfo.fileInfoExtended.width")
-    
-    @property
-    @cached
-    def height(self):
-        """The height of the image."""
-        return self.get_value("frameInfo.fileInfoExtended.height")
-    
-    @property
-    @cached
-    def depth(self):
-        """The depth of the image."""
-        return self.get_value("frameInfo.fileInfoExtended.depth")
-    
-    @property
-    @cached
-    def stokes(self):
-        """The number of Stokes parameters of the image."""
-        return self.get_value("frameInfo.fileInfoExtended.stokes")
-    
-    @property
-    @cached
-    def ndim(self):
-        """The number of dimensions of the image."""
-        return self.get_value("frameInfo.fileInfoExtended.dimensions")
-    
-    # SELECTION
-    
-    def make_active(self):
-        """Make this the active image."""
-        self.session.call_action("setActiveFrameById", self.image_id)
-        
-    def make_spatial_reference(self):
-        """Make this image the spatial reference."""
-        self.session.call_action("setSpatialReference", self._frame)
-        
-    @validate(Boolean())
-    def set_spatial_matching(self, state):
-        """Enable or disable spatial matching.
-        
-        Parameters
-        ----------
-        state : boolean
-            The desired spatial matching state.
-        """
-        self.session.call_action("setSpatialMatchingEnabled", self._frame, state)
-        
-    def make_spectral_reference(self):
-        """Make this image the spectral reference."""
-        self.session.call_action("setSpectralReference", self._frame)
-        
-    @validate(Boolean())
-    def set_spectral_matching(self, state):
-        """Enable or disable spectral matching.
-        
-        Parameters
-        ----------
-        state : boolean
-            The desired spectral matching state.
-        """
-        self.session.call_action("setSpectralMatchingEnabled", self._frame, state)
-
-    # NAVIGATION
-
-    @validate(Evaluate(Number, 0, Attr("depth"), Number.INCLUDE_MIN), Evaluate(Number, 0, Attr("stokes"), Number.INCLUDE_MIN), Boolean())
-    def set_channel_stokes(self, channel=None, stokes=None, recursive=True):
-        """Set the channel and/or Stokes.
-        
-        Parameters
-        ----------
-        channel : {0}
-            The desired channel. Defaults to the current channel.
-        stokes : {1}
-            The desired stokes. Defaults to the current Stokes.
-        recursive : {2}
-            Whether to perform the same change on all spectrally matched images. Defaults to True.
-        """
-        channel = channel or self.get_value("requiredChannel")
-        stokes = stokes or self.get_value("requiredStokes")
-        self.call_action("setChannels", channel, stokes, recursive)
-
-    @validate(Number(), Number())
-    def set_center(self, x, y):
-        """Set the center position.
-        
-        TODO: what are the units?
-        
-        Parameters
-        ----------
-        x : {0}
-            The X position.
-        y : {1}
-            The Y position.
-        """
-        self.call_action("setCenter", x, y)
-        
-    @validate(Number(), Boolean())
-    def set_zoom(self, zoom, absolute=True):
-        """Set the zoom level.
-        
-        TODO: explain this more rigorously.
-        
-        Parameters
-        ----------
-        zoom : {0}
-            The zoom level.
-        absolute : {1}
-            Whether the zoom level should be treated as absolute. By default it is adjusted by a scaling factor.
-        """
-        self.call_action("setZoom", zoom, absolute)
-        
-    # STYLE
-
-    @validate(Constant(Colormap), Boolean())
-    def set_colormap(self, colormap, invert=False):
-        """Set the colormap.
-        
-        Parameters
-        ----------
-        colormap : {0}
-            The colormap.
-        invert : {1}
-            Whether the colormap should be inverted.
-        """
-        self.call_action("renderConfig.setColorMap", colormap)
-        self.call_action("renderConfig.setInverted", invert)
-    
-    # TODO check whether this works as expected
-    @validate(Constant(Scaling), NoneOr(Number()), NoneOr(Number()), NoneOr(Number()), NoneOr(Number()))
-    def set_scaling(self, scaling, alpha=None, gamma=None, min=None, max=None):
-        """Set the colormap scaling.
-        
-        Parameters
-        ----------
-        scaling : {0}
-            The scaling type.
-        alpha : {1}
-            The alpha value (only applicable to ``LOG`` and ``POWER`` scaling types).
-        gamma : {2}
-            The gamma value (only applicable to the ``GAMMA`` scaling type).
-        min : {3}
-            The minimum of the scale. Only used if both *min* and *max* are set.
-        max : {4}
-            The maximum of the scale. Only used if both *min* and *max* are set.
-        """
-        self.call_action("renderConfig.setScaling", scaling)
-        if scaling in (Scaling.LOG, Scaling.POWER) and alpha is not None:
-            self.call_action("renderConfig.setAlpha", alpha)
-        elif scaling == Scaling.GAMMA and gamma is not None:
-            self.call_action("renderConfig.setGamma", gamma)
-        if min is not None and max is not None:
-            self.call_action("renderConfig.setCustomScale", min, max)
-    
-    @validate(Boolean())
-    def set_raster_visible(self, state):
-        """Set the raster image visibility.
-        
-        Parameters
-        ----------
-        state : {0}
-            The desired visibility state.
-        """
-        self.call_action("renderConfig.setVisible", state)
-        
-    def show_raster(self):
-        """Show the raster image."""
-        self.set_raster_visible(True)
-        
-    def hide_raster(self):
-        """Hide the raster image."""
-        self.set_raster_visible(False)
-    
-    # CONTOURS
-    
-    @validate(IterableOf(Number()), Constant(SmoothingMode), Number())
-    def configure_contours(self, levels, smoothing_mode=SmoothingMode.GAUSSIAN_BLUR, smoothing_factor=4):
-        """Configure contours.
-        
-        Parameters
-        ----------
-        levels : {0}
-            The contour levels. This may be a numeric numpy array; e.g. the output of ``arange``.
-        smoothing_mode : {1}
-            The smoothing mode.
-        smoothing_factor : {2}
-            The smoothing factor.
-        """
-        self.call_action("contourConfig.setContourConfiguration", levels, smoothing_mode, smoothing_factor)
-    
-    @validate(NoneOr(Constant(ContourDashMode)), NoneOr(Number()))
-    def set_contour_dash(self, dash_mode=None, thickness=None):
-        """Set the contour dash style.
-        
-        Parameters
-        ----------
-        dash_mode : {0}
-            The dash mode.
-        thickness : {1}
-            The dash thickness.
-        """
-        if dash_mode is not None:
-            self.call_action("contourConfig.setDashMode", dash_mode)
-        if thickness is not None:
-            self.call_action("contourConfig.setThickness", thickness)
-    
-    @validate(Color())
-    def set_contour_color(self, color):
-        """Set the contour color.
-        
-        This automatically disables use of the contour colormap.
-        
-        Parameters
-        ----------
-        color : {0}
-            The color.
-        """
-        self.call_action("contourConfig.setColor", color)
-        self.call_action("contourConfig.setColormapEnabled", False)
-    
-    @validate(Constant(Colormap), NoneOr(Number()), NoneOr(Number()))
-    def set_contour_colormap(self, colormap, bias=None, contrast=None):
-        """Set the contour colormap.
-        
-        This automatically enables use of the contour colormap.
-        
-        Parameters
-        ----------
-        colormap : {0}
-            The colormap.
-        bias : {1}
-            The colormap bias.
-        contrast : {2}
-            The colormap contrast.
-        """
-        self.call_action("contourConfig.setColormap", colormap)
-        self.call_action("contourConfig.setColormapEnabled", True)
-        if bias is not None:
-            self.call_action("contourConfig.setColormapBias", bias)
-        if contrast is not None:
-            self.call_action("contourConfig.setColormapContrast", contrast)
-    
-    def apply_contours(self):
-        """Apply the contour configuration."""
-        self.call_action("applyContours")
-    
-    def clear_contours(self):
-        """Clear the contours."""
-        self.call_action("clearContours", True)
-    
-    @validate(Boolean())
-    def set_contours_visible(self, state):
-        """Set the contour visibility.
-        
-        Parameters
-        ----------
-        state : {0}
-            The desired visibility state.
-        """
-        self.call_action("contourConfig.setVisible", state)
-    
-    def show_contours(self):
-        """Show the contours."""
-        self.set_contours_visible(True)
-        
-    def hide_contours(self):
-        """Hide the contours."""
-        self.set_contours_visible(False)
-    
-    # HISTOGRAM
-    
-    @validate(Boolean())
-    def use_cube_histogram(self, contours=False):
-        """Use the cube histogram.
-        
-        Parameters
-        ----------
-        contours : {0}
-            Apply to the contours. By default this is applied to the raster image.
-        """
-        self.call_action(f"renderConfig.setUseCubeHistogram{'Contours' if contours else ''}", True)
-    
-    @validate(Boolean())
-    def use_channel_histogram(self, contours=False):
-        """Use the channel histogram.
-        
-        Parameters
-        ----------
-        contours : {0}
-            Apply to the contours. By default this is applied to the raster image.
-        """
-        self.call_action(f"renderConfig.setUseCubeHistogram{'Contours' if contours else ''}", False)
-            
-    @validate(Number(0, 100))
-    def set_percentile_rank(self, rank):
-        """Set the percentile rank.
-        
-        Parameters
-        ----------
-        rank : {0}
-            The percentile rank.
-        """
-        self.call_action("renderConfig.setPercentileRank", rank)
-    
-    # CLOSE
-    
-    def close(self):
-        """Close this image."""
-        self.session.call_action("closeFile", self._frame)

--- a/carta/session.py
+++ b/carta/session.py
@@ -34,7 +34,7 @@ class Session:
     backend : :obj:`carta.backend.Backend`
         The backend object associated with this session. This is created automatically when a new session is created with :obj:`carta.session.Session.start_and_create`.
     debug_no_auth : boolean
-        This should be set if the backend has been started with the ``--debug_no_auth`` option. This is provided for debugging purposes only and should not be used under normal circumstances.
+        Disable authentication. This should be set if the backend has been started with the ``--debug_no_auth`` option. This is provided for debugging purposes only and should not be used under normal circumstances.
     """
     def __init__(self, session_id, protocol, browser=None, backend=None):
         self.session_id = session_id
@@ -61,7 +61,7 @@ class Session:
         token : :obj:`carta.token.Token`, optional
             The security token used by the CARTA instance. You may omit this if the URL contains a token.
         debug_no_auth : boolean, optional
-            Set this if the backend has been started with the ``--debug_no_auth`` option. This is provided for debugging purposes only and should not be used under normal circumstances. You must still pass in a *token* argument if you use this option, but you may set it to ``None``. It will be ignored.
+            Disable authentication. Set this if the backend has been started with the ``--debug_no_auth`` option. This is provided for debugging purposes only and should not be used under normal circumstances.
             
         Returns
         -------
@@ -94,7 +94,7 @@ class Session:
         timeout : integer, optional
             The number of seconds to spend retrying parsing connection information from the frontend (default: 10).
         debug_no_auth : boolean, optional
-            Set this if the backend has been started with the ``--debug_no_auth`` option. This is provided for debugging purposes only and should not be used under normal circumstances.
+            Disable authentication. Set this if the backend has been started with the ``--debug_no_auth`` option. This is provided for debugging purposes only and should not be used under normal circumstances.
             
         Returns
         -------
@@ -171,8 +171,12 @@ class Session:
         
         Raises
         ------
+        CartaBadRequest
+            If the request was invalid.
+        CartaRequestFailed
+            If the backend could not send the request to the frontend.
         CartaActionFailed
-            If a transport error occurs, or the action fails. TODO: split this into separate errors.
+            If the action failed.
         CartaBadResponse    
             If a request which was expected to have a JSON response did not have one, or if a JSON response could not be decoded.
         """

--- a/carta/session.py
+++ b/carta/session.py
@@ -14,6 +14,7 @@ from .protocol import Protocol
 from .util import logger, Macro, split_action_path, CartaScriptingException
 from .validation import validate, String, Number, Color, Constant, Boolean, NoneOr, OneOf
 
+
 class Session:
     """This object corresponds to a CARTA frontend session.
 
@@ -36,6 +37,7 @@ class Session:
     debug_no_auth : boolean
         Disable authentication. This should be set if the backend has been started with the ``--debug_no_auth`` option. This is provided for debugging purposes only and should not be used under normal circumstances.
     """
+
     def __init__(self, session_id, protocol, browser=None, backend=None):
         self.session_id = session_id
         self._protocol = protocol
@@ -291,7 +293,7 @@ class Session:
 
     # IMAGES
 
-    @validate(String(), String("\d*"))
+    @validate(String(), String(r"\d*"))
     def open_image(self, path, hdu=""):
         """Open a new image, replacing any existing images.
 
@@ -304,7 +306,7 @@ class Session:
         """
         return Image.new(self, path, hdu, False)
 
-    @validate(String(), String("\d*"))
+    @validate(String(), String(r"\d*"))
     def append_image(self, path, hdu=""):
         """Append a new image, keeping any existing images.
 

--- a/carta/session.py
+++ b/carta/session.py
@@ -31,7 +31,7 @@ class Session:
         The protocol object which handles HTTP communication with the CARTA scripting API. This is created automatically when a new session is created with one of the three class methods for creating sessions.
     browser : :obj:`carta.browser.Browser`
         The browser object associated with this session. This is created automatically when a new session is created with :obj:`carta.session.Session.create` or :obj:`carta.session.Session.start_and_create`.
-    backend : :obj:`carta.browser.Backend`
+    backend : :obj:`carta.backend.Backend`
         The backend object associated with this session. This is created automatically when a new session is created with :obj:`carta.session.Session.start_and_create`.
     debug_no_auth : boolean
         This should be set if the backend has been started with the ``--debug_no_auth`` option. This is provided for debugging purposes only and should not be used under normal circumstances.

--- a/carta/token.py
+++ b/carta/token.py
@@ -94,13 +94,14 @@ class ControllerToken(Token):
         if not self.refresh:
             raise CartaBadToken("Cannot convert a scripting token to a cookie. Refresh token expected.")
         
+        # TODO we probably don't need most of these fields at all
         return {
             "name": "Refresh-Token",
             "value": self.string,
-            "path": "/api/auth/refresh",
+            #"path": "/api/auth/refresh",
             "domain": domain,
-            "expires": self.expires.timestamp(),
-            "secure": True,
-            "httpOnly": True,
-            "sameSite": "Strict",
+            #"expires": self.expires.timestamp(),
+            #"secure": True,
+            #"httpOnly": True,
+            #"sameSite": "Strict",
         }

--- a/carta/token.py
+++ b/carta/token.py
@@ -8,6 +8,7 @@ import json
 from .util import CartaBadToken
 
 class Token:
+    """The parent token class. This should not be instantiated directly."""
     UNKNOWN, BACKEND, REFRESH, SCRIPTING = list(range(4))
     
     def __init__(self, string):
@@ -16,12 +17,26 @@ class Token:
 
 
 class BackendToken(Token):
+    """An object representing a security token used by the backend. These tokens are strings with no additional meaning, and may be generated automatically or overridden by the user with a fixed value.
+    
+    Parameters
+    ----------
+    string : string
+        The token string.
+    """
     def __init__(self, string):
         super().__init__(string)
         self.token_type = Token.BACKEND
 
 
 class ControllerToken(Token):
+    """An object representing a security token used by the controller. These tokens are JWTs (JSON Web Tokens) which encode additional information such as an expiration date. The controller uses multiple types of tokens. This interface makes use of long-lived refresh tokens (used to log into the controller and to obtain scripting tokens) and short-lived scripting tokens (used to make scripting requests).
+    
+    Parameters
+    ----------
+    string : string
+        The token string.
+    """
     def __init__(self, string):
         super().__init__(string)
     
@@ -49,48 +64,149 @@ class ControllerToken(Token):
         
     @property
     def expires(self):
+        """The expiration date of this token.
+        
+        Returns
+        -------
+        :obj:`datetime.datetime` object
+        
+        Raises
+        ------
+        CartaBadToken
+            If the token string is not a vaild JWT.
+        """
         if not hasattr(self, "_expires"):
             self._decode_jwt()
         return self._expires
         
     @property
     def username(self):
+        """The username encoded in this token.
+        
+        Returns
+        -------
+        string
+        
+        Raises
+        ------
+        CartaBadToken
+            If the token string is not a vaild JWT.
+        """
         if not hasattr(self, "_username"):
             self._decode_jwt()
         return self._username
         
     @property
     def token_type(self):
+        """The type of this token (``Token.REFRESH`` or ``Token.SCRIPTING``).
+        
+        Returns
+        -------
+        integer
+        
+        Raises
+        ------
+        CartaBadToken
+            If the token string is not a vaild JWT.
+        """
         if not hasattr(self, "_token_type"):
             self._decode_jwt()
         return self._token_type
     
     @property
     def refresh(self):
+        """Is this a refresh token?
+        
+        Returns
+        -------
+        boolean
+        
+        Raises
+        ------
+        CartaBadToken
+            If the token string is not a vaild JWT.
+        """
         return self.token_type == Token.REFRESH
     
     @property
     def scripting(self):
+        """Is this a scripting token?
+        
+        Returns
+        -------
+        boolean
+        
+        Raises
+        ------
+        CartaBadToken
+            If the token string is not a vaild JWT.
+        """
         return self.token_type == Token.SCRIPTING
             
     @classmethod
     def from_file(cls, path):
+        """Load a controller token from a file.
+        
+        Parameters
+        ----------
+        path : string
+            The path to the file.
+            
+        Returns
+        -------
+        :obj:`carta.token.ControllerToken` object
+        """
         with open(path) as f:
             string = f.read().strip()
                 
         return cls(string)
     
     def valid(self):
+        """Is this token valid?
+        
+        Returns
+        -------
+        boolean
+        
+        Raises
+        ------
+        CartaBadToken
+            If the token string is not a vaild JWT.
+        """
         if datetime.datetime.now() > self.expires:
             return False
         return True
         
         
     def save(self, path):
+        """Save this token to a file.
+        
+        Parameters
+        ----------
+        path : string
+            The path to the file where the token should be saved.
+        """
         with open(path, "w") as f:
             f.write(self.string.strip())
             
     def as_cookie(self, domain):
+        """Create a cookie from this refresh token.
+        
+        Parameters
+        ----------
+        domain : string
+            The domain to use in the cookie.
+        
+        Returns
+        -------
+        dict
+            The cookie as a dictionary of string keys and values.
+            
+        Raises
+        ------
+        CartaBadToken
+            If the token string is not a valid JWT or if this is not a refresh token. 
+        """
         if not self.refresh:
             raise CartaBadToken("Cannot convert a scripting token to a cookie. Refresh token expected.")
         

--- a/carta/token.py
+++ b/carta/token.py
@@ -7,8 +7,10 @@ import json
 
 from .util import CartaBadToken
 
+
 class Token:
     """The parent token class. This should not be instantiated directly."""
+
     def __init__(self, string):
         self.string = string
 
@@ -21,6 +23,7 @@ class BackendToken(Token):
     string : string
         The token string.
     """
+
     def __init__(self, string):
         super().__init__(string)
 
@@ -33,6 +36,7 @@ class ControllerToken(Token):
     string : string
         The token string.
     """
+
     def __init__(self, string):
         super().__init__(string)
 
@@ -40,7 +44,7 @@ class ControllerToken(Token):
         try:
             payload = self.string.split('.')[1]
 
-            payload = payload.ljust(4 * math.ceil(len(payload)/4), "=")
+            payload = payload.ljust(4 * math.ceil(len(payload) / 4), "=")
 
             decoded_payload = base64.b64decode(payload)
             decoded_dict = json.loads(decoded_payload.decode("utf-8"))
@@ -163,7 +167,6 @@ class ControllerToken(Token):
         if datetime.datetime.now() > self.expires:
             return False
         return True
-
 
     def save(self, path):
         """Save this token to a file.

--- a/carta/token.py
+++ b/carta/token.py
@@ -9,7 +9,18 @@ from .util import CartaBadToken
 
 
 class Token:
-    """The parent token class. This should not be instantiated directly."""
+    """The parent token class. This should not be instantiated directly.
+
+    Parameters
+    ----------
+    string : string
+        The token string.
+
+    Attributes
+    ----------
+    string : string
+        The token string.
+    """
 
     def __init__(self, string):
         self.string = string

--- a/carta/token.py
+++ b/carta/token.py
@@ -15,7 +15,7 @@ class Token:
 
 class BackendToken(Token):
     """An object representing a security token used by the backend. These tokens are strings with no additional meaning, and may be generated automatically or overridden by the user with a fixed value.
-    
+
     Parameters
     ----------
     string : string
@@ -27,7 +27,7 @@ class BackendToken(Token):
 
 class ControllerToken(Token):
     """An object representing a security token used by the controller. These tokens are JWTs (JSON Web Tokens) which encode additional information such as an expiration date. The controller uses multiple types of tokens. This interface makes use of long-lived refresh tokens (used to log into the controller and to obtain scripting tokens) and short-lived scripting tokens (used to make scripting requests).
-    
+
     Parameters
     ----------
     string : string
@@ -35,16 +35,16 @@ class ControllerToken(Token):
     """
     def __init__(self, string):
         super().__init__(string)
-    
+
     def _decode_jwt(self):
         try:
             payload = self.string.split('.')[1]
-        
+
             payload = payload.ljust(4 * math.ceil(len(payload)/4), "=")
-            
+
             decoded_payload = base64.b64decode(payload)
             decoded_dict = json.loads(decoded_payload.decode("utf-8"))
-                        
+
             exp = int(decoded_dict["exp"])
             self._expires = datetime.datetime.fromtimestamp(exp)
             self._username = decoded_dict["username"]
@@ -52,19 +52,19 @@ class ControllerToken(Token):
                 self._refresh = True
             if "scripting" in decoded_dict:
                 self._scripting = True
-            
+
         except Exception as e:
             raise CartaBadToken(f"String {self.string} cannot be converted to a controller token: {e}")
-        
+
     @property
     def expires(self):
         """The expiration date of this token.
-        
+
         Returns
         -------
         :obj:`datetime.datetime` object
             The expiration date.
-        
+
         Raises
         ------
         CartaBadToken
@@ -73,16 +73,16 @@ class ControllerToken(Token):
         if not hasattr(self, "_expires"):
             self._decode_jwt()
         return self._expires
-        
+
     @property
     def username(self):
         """The username encoded in this token.
-        
+
         Returns
         -------
         string
             The username.
-        
+
         Raises
         ------
         CartaBadToken
@@ -91,16 +91,16 @@ class ControllerToken(Token):
         if not hasattr(self, "_username"):
             self._decode_jwt()
         return self._username
-        
+
     @property
     def refresh(self):
         """Is this a refresh token?
-        
+
         Returns
         -------
         boolean
             Whether this is a refresh token.
-        
+
         Raises
         ------
         CartaBadToken
@@ -109,16 +109,16 @@ class ControllerToken(Token):
         if not hasattr(self, "_refresh"):
             self._decode_jwt()
         return self._refresh
-        
+
     @property
     def scripting(self):
         """Is this a scripting token?
-        
+
         Returns
         -------
         boolean
             Whether this is a scripting token.
-        
+
         Raises
         ------
         CartaBadToken
@@ -127,16 +127,16 @@ class ControllerToken(Token):
         if not hasattr(self, "_scripting"):
             self._decode_jwt()
         return self._scripting
-            
+
     @classmethod
     def from_file(cls, path):
         """Load a controller token from a file.
-        
+
         Parameters
         ----------
         path : string
             The path to the file.
-            
+
         Returns
         -------
         :obj:`carta.token.ControllerToken`
@@ -144,17 +144,17 @@ class ControllerToken(Token):
         """
         with open(path) as f:
             string = f.read().strip()
-                            
+
         return cls(string)
-    
+
     def valid(self):
         """Is this token valid?
-        
+
         Returns
         -------
         boolean
             Whether this token is valid.
-        
+
         Raises
         ------
         CartaBadToken
@@ -163,11 +163,11 @@ class ControllerToken(Token):
         if datetime.datetime.now() > self.expires:
             return False
         return True
-        
-        
+
+
     def save(self, path):
         """Save this token to a file.
-        
+
         Parameters
         ----------
         path : string
@@ -175,26 +175,26 @@ class ControllerToken(Token):
         """
         with open(path, "w") as f:
             f.write(self.string.strip())
-            
+
     def as_cookie(self, domain):
         """Create a cookie from this refresh token.
-        
+
         Parameters
         ----------
         domain : string
             The domain to use in the cookie.
-        
+
         Returns
         -------
         dict
             The cookie as a dictionary of string keys and values.
-            
+
         Raises
         ------
         CartaBadToken
-            If the token string is not a valid JWT or if this is not a refresh token. 
+            If the token string is not a valid JWT or if this is not a refresh token.
         """
-        
+
         return {
             "name": "Refresh-Token",
             "value": self.string,

--- a/carta/token.py
+++ b/carta/token.py
@@ -69,6 +69,7 @@ class ControllerToken(Token):
         Returns
         -------
         :obj:`datetime.datetime` object
+            The expiration date.
         
         Raises
         ------
@@ -86,6 +87,7 @@ class ControllerToken(Token):
         Returns
         -------
         string
+            The username.
         
         Raises
         ------
@@ -98,11 +100,12 @@ class ControllerToken(Token):
         
     @property
     def token_type(self):
-        """The type of this token (``Token.REFRESH`` or ``Token.SCRIPTING``).
+        """The type of this token.
         
         Returns
         -------
         integer
+            ``Token.REFRESH`` or ``Token.SCRIPTING``.
         
         Raises
         ------
@@ -120,6 +123,7 @@ class ControllerToken(Token):
         Returns
         -------
         boolean
+            Whether this is a refresh token.
         
         Raises
         ------
@@ -135,6 +139,7 @@ class ControllerToken(Token):
         Returns
         -------
         boolean
+            Whether this is a scripting token.
         
         Raises
         ------
@@ -154,7 +159,8 @@ class ControllerToken(Token):
             
         Returns
         -------
-        :obj:`carta.token.ControllerToken` object
+        :obj:`carta.token.ControllerToken`
+            The controller token.
         """
         with open(path) as f:
             string = f.read().strip()
@@ -167,6 +173,7 @@ class ControllerToken(Token):
         Returns
         -------
         boolean
+            Whether this token is valid.
         
         Raises
         ------

--- a/carta/token.py
+++ b/carta/token.py
@@ -1,0 +1,106 @@
+"""This module provides classes and functions for managing backend and controller tokens."""
+
+import math
+import base64
+import datetime
+import json
+
+from .util import CartaBadToken
+
+class Token:
+    UNKNOWN, BACKEND, REFRESH, SCRIPTING = list(range(4))
+    
+    def __init__(self, string):
+        self.string = string
+        self.token_type = Token.UNKNOWN
+
+
+class BackendToken(Token):
+    def __init__(self, string):
+        super().__init__(string)
+        self.token_type = Token.BACKEND
+
+
+class ControllerToken(Token):
+    def __init__(self, string):
+        super().__init__(string)
+    
+    def _decode_jwt(self):
+        try:
+            payload = self.string.split('.')[1]
+        
+            payload = payload.ljust(4 * math.ceil(len(payload)/4), "=")
+            
+            decoded_payload = base64.b64decode(payload)
+            decoded_dict = json.loads(decoded_payload.decode("utf-8"))
+            
+            exp = int(decoded_dict["exp"])
+            self._expires = datetime.datetime.fromtimestamp(exp)
+            self._username = decoded_dict["username"]
+            if "refreshToken" in decoded_dict:
+                self._token_type = Token.REFRESH
+            elif "scripting" in decoded_dict:
+                self._token_type = Token.SCRIPTING
+            else:
+                raise ValueError("This is not a refresh token or a scripting token.")
+            
+        except Exception as e:
+            raise CartaBadToken(f"String {self.string} cannot be converted to a controller token: {e}")
+        
+    @property
+    def expires(self):
+        if not hasattr(self, "_expires"):
+            self._decode_jwt()
+        return self._expires
+        
+    @property
+    def username(self):
+        if not hasattr(self, "_username"):
+            self._decode_jwt()
+        return self._username
+        
+    @property
+    def token_type(self):
+        if not hasattr(self, "_token_type"):
+            self._decode_jwt()
+        return self._token_type
+    
+    @property
+    def refresh(self):
+        return self.token_type == Token.REFRESH
+    
+    @property
+    def scripting(self):
+        return self.token_type == Token.SCRIPTING
+            
+    @classmethod
+    def from_file(cls, path):
+        with open(path) as f:
+            string = f.read().strip()
+                
+        return cls(string)
+    
+    def valid(self):
+        if datetime.datetime.now() > self.expires:
+            return False
+        return True
+        
+        
+    def save(self, path):
+        with open(path, "w") as f:
+            f.write(self.string.strip())
+            
+    def as_cookie(self, domain):
+        if not self.refresh:
+            raise CartaBadToken("Cannot convert a scripting token to a cookie. Refresh token expected.")
+        
+        return {
+            "name": "Refresh-Token",
+            "value": self.string,
+            "path": "/api/auth/refresh",
+            "domain": domain,
+            "expires": self.expires.timestamp(),
+            "secure": True,
+            "httpOnly": True,
+            "sameSite": "Strict",
+        }

--- a/carta/util.py
+++ b/carta/util.py
@@ -3,6 +3,7 @@
 import logging
 import json
 import functools
+import re
 
 logger = logging.getLogger("carta_scripting")
 logger.setLevel(logging.WARN)
@@ -109,7 +110,7 @@ def cached(func):
         return self._cache[func.__name__]
 
     if newfunc.__doc__ is not None:
-        newfunc.__doc__ = newfunc.__doc__ + "\n\nThis value is transparently cached on the parent object."
+        newfunc.__doc__ = re.sub(r"($|\n)", r" This value is transparently cached on the parent object.\1", newfunc.__doc__, 1)
 
     return newfunc
 

--- a/carta/util.py
+++ b/carta/util.py
@@ -56,7 +56,7 @@ class CartaBadResponse(CartaScriptingException):
 
 class Macro:
     """A placeholder for a target and a variable which will be evaluated dynamically by the frontend.
-    
+
     Parameters
     ----------
     target : str
@@ -74,7 +74,7 @@ class Macro:
     def __init__(self, target, variable):
         self.target = target
         self.variable = variable
-        
+
     def __repr__(self):
         return f"Macro('{self.target}', '{self.variable}')"
 
@@ -93,7 +93,7 @@ class CartaEncoder(json.JSONEncoder):
 
 def cached(func):
     """A decorator which transparently caches the return value of the decorated method on the parent object.
-    
+
     This should only be used on methods with return values which are not expected to change for the lifetime of the object.
     """
     @functools.wraps(func)
@@ -103,12 +103,12 @@ def cached(func):
 
         if func.__name__ not in self._cache:
             self._cache[func.__name__] = func(self, *args)
-            
+
         return self._cache[func.__name__]
-    
+
     if newfunc.__doc__ is not None:
         newfunc.__doc__ = newfunc.__doc__ + "\n\nThis value is transparently cached on the parent object."
-        
+
     return newfunc
 
 

--- a/carta/util.py
+++ b/carta/util.py
@@ -3,6 +3,7 @@
 import logging
 import json
 import functools
+import re
 
 logger = logging.getLogger("carta_scripting")
 logger.setLevel(logging.WARN)
@@ -11,6 +12,11 @@ logger.addHandler(logging.StreamHandler())
 
 class CartaScriptingException(Exception):
     """The top-level exception for all scripting errors."""
+    pass
+
+
+class CartaBadSession(CartaScriptingException):
+    """An exception for invalid session specifications."""
     pass
 
 
@@ -85,3 +91,10 @@ def cached(func):
         newfunc.__doc__ = newfunc.__doc__ + "\n\nThis value is transparently cached on the parent object."
         
     return newfunc
+
+
+def token_from_url(url):
+    m = re.match(".*\?token=(.*)", url)
+    if m:
+        return m.group(1)
+    return None

--- a/carta/util.py
+++ b/carta/util.py
@@ -3,7 +3,6 @@
 import logging
 import json
 import functools
-import re
 
 logger = logging.getLogger("carta_scripting")
 logger.setLevel(logging.WARN)
@@ -32,6 +31,14 @@ class CartaActionFailed(CartaScriptingException):
 
 class CartaBadResponse(CartaScriptingException):
     """An exception for unexpected responses."""
+    pass
+
+class CartaBadToken(CartaScriptingException):
+    """An exception for expired and invalid tokens"""
+    pass
+
+class CartaBadUrl(CartaScriptingException):
+    """An exception for invalid URLs"""
     pass
 
 
@@ -93,8 +100,8 @@ def cached(func):
     return newfunc
 
 
-def token_from_url(url):
-    m = re.match(".*\?token=(.*)", url)
-    if m:
-        return m.group(1)
-    return None
+def split_action_path(path):
+    """Extracts a path to a frontend object store and an action from a combined path.
+    """
+    parts = path.split('.')
+    return '.'.join(parts[:-1]), parts[-1]

--- a/carta/util.py
+++ b/carta/util.py
@@ -71,6 +71,7 @@ class Macro:
     variable : str
         The variable on the target object.
     """
+
     def __init__(self, target, variable):
         self.target = target
         self.variable = variable
@@ -81,10 +82,11 @@ class Macro:
 
 class CartaEncoder(json.JSONEncoder):
     """A custom encoder to JSON which correctly serialises :obj:`carta.util.Macro` objects and numpy arrays."""
+
     def default(self, obj):
         """ This method is overridden from the parent class and performs the substitution."""
         if isinstance(obj, Macro):
-            return {"macroTarget" : obj.target, "macroVariable" : obj.variable}
+            return {"macroTarget": obj.target, "macroVariable": obj.variable}
         if type(obj).__module__ == "numpy" and type(obj).__name__ == "ndarray":
             # The condition is a workaround to avoid importing numpy
             return obj.tolist()

--- a/carta/util.py
+++ b/carta/util.py
@@ -15,30 +15,42 @@ class CartaScriptingException(Exception):
 
 
 class CartaBadSession(CartaScriptingException):
-    """An exception for invalid session specifications."""
+    """A session could not be constructed."""
+    pass
+
+
+class CartaBadToken(CartaScriptingException):
+    """A token has expired or is invalid."""
+    pass
+
+
+class CartaBadUrl(CartaScriptingException):
+    """An URL is invalid."""
     pass
 
 
 class CartaValidationFailed(CartaScriptingException):
-    """An exception for parameter validation errors."""
+    """Invalid parameters were passed to a function with a :obj:`carta.validation.validate` decorator."""
+    pass
+
+
+class CartaBadRequest(CartaScriptingException):
+    """A request sent to the CARTA backend was rejected."""
+    pass
+
+
+class CartaRequestFailed(CartaScriptingException):
+    """A request received a failure response from the CARTA backend."""
     pass
 
 
 class CartaActionFailed(CartaScriptingException):
-    """An exception for action failures."""
+    """An action request received a failure response from the CARTA frontend."""
     pass
 
 
 class CartaBadResponse(CartaScriptingException):
-    """An exception for unexpected responses."""
-    pass
-
-class CartaBadToken(CartaScriptingException):
-    """An exception for expired and invalid tokens"""
-    pass
-
-class CartaBadUrl(CartaScriptingException):
-    """An exception for invalid URLs"""
+    """An action request received an unexpected response from the CARTA frontend."""
     pass
 
 

--- a/carta/validation.py
+++ b/carta/validation.py
@@ -8,17 +8,17 @@ from .util import CartaValidationFailed
 
 class Parameter:
     """The top-level class for parameter validation."""
-    
+
     def validate(self, value, parent):
         """Validate the value provided.
-        
+
         Parameters
         ----------
         value
             The value to be validated.
         parent
             The object which owns the decorated method.
-        
+
         Raises
         ------
         TypeError
@@ -29,7 +29,7 @@ class Parameter:
             If the check depends on an attribute on the parent object of the decorated method, and it does not exist.
         """
         raise NotImplementedError
-    
+
     @property
     def description(self):
         """A human-readable description of this parameter descriptor."""
@@ -37,14 +37,14 @@ class Parameter:
 
 class String(Parameter):
     """A string parameter.
-    
+
     Parameters
     ----------
     regex : str, optional
         A regular expression string which the parameter must match.
     ignorecase : bool, optional
         Whether the regular expression match should be case-insensitive.
-        
+
     Attributes
     ----------
     regex : str
@@ -52,22 +52,22 @@ class String(Parameter):
     flags : int
         The flags to use when matching the regular expression. This is set to :obj:`re.IGNORECASE` or zero.
     """
-    
+
     def __init__(self, regex=None, ignorecase=False):
         self.regex = regex
         self.flags = re.IGNORECASE if ignorecase else 0
-        
+
     def validate(self, value, parent):
         """Check if the value is a string and if it matches a regex if one was provided.
-        
+
         See :obj:`carta.validation.Parameter.validate` for general information about this method.
         """
         if not isinstance(value, str):
             raise TypeError(f"{value} has type {type(value)} but a string was expected.")
-        
+
         if self.regex is not None and not re.search(self.regex, value, self.flags):
             raise ValueError(f"{value} does not match {self.regex}")
-    
+
     @property
     def description(self):
         if self.regex:
@@ -75,8 +75,8 @@ class String(Parameter):
         return "a string"
 
 class Number(Parameter):
-    """An integer or floating point scalar numeric parameter. 
-    
+    """An integer or floating point scalar numeric parameter.
+
     Parameters
     ----------
     min : number, optional
@@ -85,7 +85,7 @@ class Number(Parameter):
         The upper bound.
     interval : int
         A bitmask which describes whether the bounds are included or excluded. The constant attributes defined on this class should be used. By default both bounds are included.
-        
+
     Attributes
     ----------
     min : number
@@ -97,27 +97,27 @@ class Number(Parameter):
     max_included : bool
         Whether the upper bound is included.
     """
-    
+
     EXCLUDE, INCLUDE_MIN, INCLUDE_MAX, INCLUDE = range(4)
-    
+
     def __init__(self, min=None, max=None, interval=INCLUDE):
         self.min = min
         self.max = max
         self.min_included = bool(interval & self.INCLUDE_MIN)
         self.max_included = bool(interval & self.INCLUDE_MAX)
-        
+
     def validate(self, value, parent):
         """Check if the value is a number and falls within any bounds that were provided.
-        
+
         We check the type by attempting to convert the value to ``float``. We do this instead of comparing types directly to support compatible numeric types from e.g. the numpy library without having to anticipate and check for them explicitly and without introducing import dependencies.
-                
+
         See :obj:`carta.validation.Parameter.validate` for general information about this method.
         """
         try:
             float(value)
         except TypeError:
             raise TypeError(f"{value} has type {type(value)} but a number was expected.")
-        
+
         if self.min is not None:
             if self.min_included:
                 if value < self.min:
@@ -125,7 +125,7 @@ class Number(Parameter):
             else:
                 if value <= self.min:
                     raise ValueError(f"{value} is smaller than or equal to minimum value {self.min}.")
-        
+
         if self.max is not None:
             if self.max_included:
                 if value > self.max:
@@ -133,50 +133,50 @@ class Number(Parameter):
             else:
                 if value >= self.max:
                     raise ValueError(f"{value} is greater than or equal to maximum value {self.max}.")
-    
+
     @property
     def description(self):
         desc = ["a number"]
-        
+
         if self.min is not None:
             desc.append(f"greater than{' or equal to' if self.min_included else ''} ``{self.min}``")
-            
+
             if self.max is not None:
                 desc.append("and")
-        
+
         if self.max is not None:
             desc.append(f"smaller than{' or equal to' if self.max_included else ''} ``{self.max}``")
-        
+
         return " ".join(desc)
-        
-        
+
+
 class Boolean(Parameter):
     """A boolean parameter."""
-    
+
     def validate(self, value, parent):
-        """Check if the value is boolean. It may be expressed as a numeric 1 or 0 value. 
-        
+        """Check if the value is boolean. It may be expressed as a numeric 1 or 0 value.
+
         See :obj:`carta.validation.Parameter.validate` for general information about this method.
         """
         if value not in (0, 1):
             raise TypeError(f"{value} is not a boolean value.")
-        
+
     @property
     def description(self):
         return "a boolean"
-        
+
 
 class NoneParameter(Parameter):
     """A parameter which must be ``None``. This is not intended to be used directly; it is used together with :obj:`carta.validation.Union` for optional parameters with a default value of ``None``."""
-    
+
     def validate(self, value, parent):
-        """Check if the value is ``None``. 
-        
+        """Check if the value is ``None``.
+
         See :obj:`carta.validation.Parameter.validate` for general information about this method.
         """
         if value is not None:
             raise ValueError(f"{value} is not None.")
-        
+
     @property
     def description(self):
         return "``None``"
@@ -184,14 +184,14 @@ class NoneParameter(Parameter):
 
 class OneOf(Parameter):
     """A parameter which must be one of several discrete values.
-    
+
     Parameters
     ----------
     *options : iterable
         An iterable of permitted values.
     normalize : function, optional
         A function for applying a transformation to the value before the comparison: for example, ``lambda x: x.lower()``.
-        
+
     Attributes
     ----------
     options : iterable
@@ -202,18 +202,18 @@ class OneOf(Parameter):
     def __init__(self, *options, normalize=None):
         self.options = options
         self.normalize = normalize
-        
+
     def validate(self, value, parent):
-        """Check if the value is equal to one of the provided options. If a normalization function is given, this is first used to transform the value. 
-        
+        """Check if the value is equal to one of the provided options. If a normalization function is given, this is first used to transform the value.
+
         See :obj:`carta.validation.Parameter.validate` for general information about this method.
         """
         if self.normalize is not None:
             value = self.normalize(value)
-        
+
         if value not in self.options:
             raise ValueError(f"{value} is not {self.description}")
-        
+
     @property
     def description(self):
         return f"one of {', '.join(str(o) for o in self.options)}"
@@ -221,14 +221,14 @@ class OneOf(Parameter):
 
 class Union(Parameter):
     """A union of other parameter descriptors.
-    
+
     Parameters
     ----------
     options : iterable of :obj:`carta.validation.Parameter` objects
         An iterable of valid descriptors for this parameter
     description : str, optional
         A custom description. The default is generated from the descriptions of the provided options.
-        
+
     Attributes
     ----------
     options : iterable of :obj:`carta.validation.Parameter` objects
@@ -237,14 +237,14 @@ class Union(Parameter):
     def __init__(self, options, description=None):
         self.options = options
         self._description = description
-        
+
     def validate(self, value, parent):
         """Check if the value can be validated with one of the provided descriptors. The descriptors are evaluated in the order that they are given, and the function exits after the first successful validation.
-        
+
         See :obj:`carta.validation.Parameter.validate` for general information about this method.
         """
         valid = False
-        
+
         for option in self.options:
             try:
                 option.validate(value, parent)
@@ -253,10 +253,10 @@ class Union(Parameter):
             else:
                 valid = True
                 break
-        
+
         if not valid:
             raise ValueError(f"{value} is not {self.description}.")
-        
+
     @property
     def description(self):
         return self._description or " or ".join(o.description for o in self.options)
@@ -264,12 +264,12 @@ class Union(Parameter):
 
 class Constant(OneOf):
     """A parameter which must match a class property on the provided class. Intended for use with the constants defined in :obj:`carta.constants`.
-    
+
     Parameters
     ----------
     clazz : class
         The parameter must match one of the properties of this class.
-    
+
     Attributes
     ----------
     options : iterable
@@ -281,7 +281,7 @@ class Constant(OneOf):
         options = set(v for k, v in inspect.getmembers(clazz, lambda x:not(inspect.isroutine(x))) if not k.startswith("__"))
         super().__init__(*options)
         self.clazz = clazz
-        
+
     @property
     def description(self):
         if self.clazz.__module__ is None or self.clazz.__module__ == str.__class__.__module__:
@@ -289,16 +289,16 @@ class Constant(OneOf):
         else:
             fullname = self.clazz.__module__ + '.' + self.clazz.__name__
         return f"a class property of :obj:`{fullname}`"
-        
+
 
 class NoneOr(Union):
     """A parameter which can match the given descriptor or ``None``. Used for optional parameters which are ``None`` by default.
-    
+
     Parameters
     ----------
     param : :obj:`carta.validation.Parameter`
         The parameter descriptor.
-    
+
     Attributes
     ----------
     param : :obj:`carta.validation.Parameter`
@@ -314,12 +314,12 @@ class NoneOr(Union):
 
 class IterableOf(Parameter):
     """An iterable of values which must match the given descriptor.
-    
+
     Parameters
     ----------
     param : :obj:`carta.validation.Parameter`
         The parameter descriptor.
-    
+
     Attributes
     ----------
     param : :obj:`carta.validation.Parameter`
@@ -327,41 +327,41 @@ class IterableOf(Parameter):
     """
     def __init__(self, param):
         self.param = param
-    
+
     def validate(self, value, parent):
         """Check if each element of the iterable can be validated with the given descriptor.
-        
+
         See :obj:`carta.validation.Parameter.validate` for general information about this method.
         """
         for v in value:
             self.param.validate(v, parent)
-        
+
     @property
     def description(self):
         return f"an iterable of {self.param.description}"
-            
+
 
 COLORNAMES = ('aliceblue', 'antiquewhite', 'aqua', 'aquamarine', 'azure', 'beige', 'bisque', 'black', 'blanchedalmond', 'blue', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgrey', 'darkgreen', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'fuchsia', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'gray', 'grey', 'green', 'greenyellow', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgrey', 'lightgreen', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'lime', 'limegreen', 'linen', 'magenta', 'maroon', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'navy', 'oldlace', 'olive', 'olivedrab', 'orange', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'purple', 'red', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'silver', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'teal', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'white', 'whitesmoke', 'yellow', 'yellowgreen')
 
 
 class TupleColor(Parameter):
     """An HTML color tuple. Not intended to be used directly; you probably want :obj:`carta.validation.Color` instead."""
-    
+
     def _assert_length(self, params, number):
         if len(params) != number:
             raise ValueError(f"expected {number} parameters but got {len(params)}.")
-        
+
     def _assert_percentage(self, param):
         if not param.endswith("%") or not 0 <= float(param[:-1]) <= 100:
             raise ValueError(f"{param} is not a valid percentage.")
-        
+
     def _assert_between(self, param, min, max):
         if not min <= float(param) <= max:
             raise ValueError(f"{param} is not a number between {min} and {max}.")
-    
+
     def _validate_rgb(self, params):
         self._assert_length(params, 3)
-                
+
         try:
             for p in params:
                 self._assert_percentage(p)
@@ -371,44 +371,44 @@ class TupleColor(Parameter):
                     self._assert_between(p, 0, 255)
             except ValueError:
                 raise ValueError("parameters must either all be percentages or all be numbers between 0 and 255.")
-    
+
     def _validate_rgba(self, params):
         self._assert_length(params, 4)
         self._validate_rgb(params[:3])
         self._assert_between(params[3], 0, 1)
-    
+
     def _validate_hsl(self, params):
         self._assert_length(params, 3)
         self._assert_between(params[0], 0, 360)
         self._assert_percentage(params[1])
         self._assert_percentage(params[2])
-    
+
     def _validate_hsla(self, params):
         self._assert_length(params, 4)
         self._validate_hsl(params[:3])
         self._assert_between(params[3], 0, 1)
-    
+
     def validate(self, value, parent):
         """Check if the value can be parsed as a color tuple, and validate the tuple elements.
-        
+
         See :obj:`carta.validation.Parameter.validate` for general information about this method.
         """
         value = re.sub('\s', '', value)
-        
+
         m = re.match('(hsla?|rgba?)\((.*)\)', value)
         if m is None:
             raise ValueError(f"{value} is not {self.description}.")
-        
+
         func, params = m.groups()
         try:
             getattr(self, f"_validate_{func}")(params.split(","))
         except (TypeError, ValueError) as e:
             raise ValueError(f"{value} is not a valid {func.upper()} color tuple: {e}")
-        
+
     @property
     def description(self):
         return "an HTML color tuple"
-        
+
 
 class Color(Union):
     """Any valid HTML color specification: a 3- or 6-digit hex triplet, an RBG(A) or HSL(A) tuple, or one of the 147 named colors."""
@@ -429,14 +429,14 @@ class Attr(str):
 
 class Evaluate(Parameter):
     """A descriptor which is constructed at runtime using properties of the parent object of the decorated method.
-    
+
     Parameters
     ----------
     paramclass : a :obj:`carta.validation.Parameter` class
         The class of the parameter descriptor to construct.
     *args : iterable
         Arguments to pass to the constructor; either literals or :obj:`carta.validation.Attr` objects which will be evaluated from properties on the parent object at runtime.
-    
+
     Attributes
     ----------
     paramclass : a :obj:`carta.validation.Parameter` class
@@ -444,27 +444,27 @@ class Evaluate(Parameter):
     args : iterable
         Arguments to pass to the constructor.
     """
-    
+
     def __init__(self, paramclass, *args):
         self.paramclass = paramclass
         self.args = args
-        
+
     def validate(self, value, parent):
         args = list(self.args)
         for i, arg in enumerate(args):
             if isinstance(arg, Attr):
                 args[i] = getattr(parent, arg)
-                
+
         param = self.paramclass(*args)
         param.validate(value, parent)
-        
+
     @property
     def description(self):
         args = list(self.args)
         for i, arg in enumerate(args):
             if isinstance(arg, Attr):
                 args[i] = f"self.{arg}"
-        
+
         # This is a bit magic, and relies on the lack of any kind of type checking in the constructors
         param = self.paramclass(*args)
         return f"{param.description}, evaluated at runtime"
@@ -472,41 +472,41 @@ class Evaluate(Parameter):
 
 def validate(*vargs):
     """The function which returns the decorator used to validate method parameters.
-    
+
     It is assumed that the function to be decorated is an object method and the first parameter is ``self``; this parameter is therefore ignored by the decorator. The remaining positional parameters are validated in order using the provided descriptors. The descriptors are also combined pairwise with the parameter names in the signature of the original function to create a dictionary for validating keyword parameters.
-    
+
     Functions with ``*args`` or ``**kwargs`` are not currently supported: use iterables and explicit keyword parameters instead.
-    
+
     The decorator inserts the descriptions of the parameters into the docstring of the decorated function, if placeholders have been left for them in the original docstring. The descriptions are passed as positional parameters to :obj:`str.format`.
-    
+
     The ``self`` parameter is passed into the validation method of each descriptor, so that checks can depend on properties to be evaluated at runtime (this is currently used by :obj:`carta.validation.Evaluate`).
 
     The decorated function raises a :obj:`carta.util.CartaValidationFailed` if one of the parameters fails to validate.
-    
+
     Parameters
     ----------
     *vargs : iterable of :obj:`carta.validation.Parameter` objects
         Descriptors to be used to validate the function parameters, in the same order as the parameters.
-        
+
     Returns
     -------
     function
         The decorator function.
     """
-        
+
     def decorator(func):
         kwvargs = {k:v for (k, v) in zip(inspect.getfullargspec(func).args[1:], vargs)}
         STRIP_OBJ = re.compile(":obj:`(.*)`")
         STRIP_CODE = re.compile("``(.*)``")
         PRESERVE = re.compile("(:obj:`.+?`|``.+?``)")
         ITALICISE = re.compile(r"^([\s.,]*)(.+?)([\s.,]*)$")
-        
+
         @functools.wraps(func)
         def newfunc(self, *args, **kwargs):
             try:
                 for param, value in zip(vargs, args):
                     param.validate(value, self)
-                    
+
                 for key, value in kwargs.items():
                     try:
                         param = kwvargs[key]
@@ -520,7 +520,7 @@ def validate(*vargs):
                 msg = STRIP_CODE.sub(r"\1", msg)
                 raise CartaValidationFailed(f"Invalid function parameter: {msg}")
             return func(self, *args, **kwargs)
-        
+
         # If descriptions contain formatting they are not formatted correctly by Sphinx
         def fix_description(s):
             parts = PRESERVE.split(s)
@@ -531,9 +531,9 @@ def validate(*vargs):
                     continue
                 parts[i] = ITALICISE.sub(r"\1*\2*\3", p)
             return "".join(parts)
-        
+
         if newfunc.__doc__ is not None:
             newfunc.__doc__ = newfunc.__doc__.format(*(fix_description(p.description) for p in vargs))
-                    
+
         return newfunc
     return decorator

--- a/carta/validation.py
+++ b/carta/validation.py
@@ -1,4 +1,4 @@
-"""This module provides a collection of descriptors of the permitted types and values of parameters passed to :obj:`carta.client.Session` and :obj:`carta.client.Image` methods. They are associated with methods through a decorator which performs the validation at runtime and also injects parameter descriptions into the methods' docstrings."""
+"""This module provides a collection of descriptors of the permitted types and values of parameters passed to :obj:`carta.session.Session` and :obj:`carta.image.Image` methods. They are associated with methods through a decorator which performs the validation at runtime and also injects parameter descriptions into the methods' docstrings."""
 
 import re
 import functools

--- a/carta/validation.py
+++ b/carta/validation.py
@@ -495,7 +495,7 @@ def validate(*vargs):
     """
         
     def decorator(func):
-        kwvargs = {k:v for (k, v) in zip(inspect.getfullargspec(func).args, vargs)}
+        kwvargs = {k:v for (k, v) in zip(inspect.getfullargspec(func).args[1:], vargs)}
         STRIP_OBJ = re.compile(":obj:`(.*)`")
         STRIP_CODE = re.compile("``(.*)``")
         PRESERVE = re.compile("(:obj:`.+?`|``.+?``)")

--- a/carta/validation.py
+++ b/carta/validation.py
@@ -248,7 +248,7 @@ class Union(Parameter):
         for option in self.options:
             try:
                 option.validate(value, parent)
-            except:
+            except (ValueError, TypeError):
                 pass
             else:
                 valid = True
@@ -365,11 +365,11 @@ class TupleColor(Parameter):
         try:
             for p in params:
                 self._assert_percentage(p)
-        except:
+        except ValueError:
             try:
                 for p in params:
                     self._assert_between(p, 0, 255)
-            except:
+            except ValueError:
                 raise ValueError("parameters must either all be percentages or all be numbers between 0 and 255.")
     
     def _validate_rgba(self, params):

--- a/carta/validation.py
+++ b/carta/validation.py
@@ -6,6 +6,7 @@ import inspect
 
 from .util import CartaValidationFailed
 
+
 class Parameter:
     """The top-level class for parameter validation."""
 
@@ -34,6 +35,7 @@ class Parameter:
     def description(self):
         """A human-readable description of this parameter descriptor."""
         return "UNKNOWN"
+
 
 class String(Parameter):
     """A string parameter.
@@ -73,6 +75,7 @@ class String(Parameter):
         if self.regex:
             return f"`a string matching` ``{self.regex}``"
         return "a string"
+
 
 class Number(Parameter):
     """An integer or floating point scalar numeric parameter.
@@ -199,6 +202,7 @@ class OneOf(Parameter):
     normalize : function, optional
         A function for applying a transformation to the value before the comparison.
     """
+
     def __init__(self, *options, normalize=None):
         self.options = options
         self.normalize = normalize
@@ -234,6 +238,7 @@ class Union(Parameter):
     options : iterable of :obj:`carta.validation.Parameter` objects
         An iterable of valid descriptors for this parameter.
     """
+
     def __init__(self, options, description=None):
         self.options = options
         self._description = description
@@ -277,8 +282,9 @@ class Constant(OneOf):
     clazz : class
         The parameter must match one of the properties of this class.
     """
+
     def __init__(self, clazz):
-        options = set(v for k, v in inspect.getmembers(clazz, lambda x:not(inspect.isroutine(x))) if not k.startswith("__"))
+        options = set(v for k, v in inspect.getmembers(clazz, lambda x: not(inspect.isroutine(x))) if not k.startswith("__"))
         super().__init__(*options)
         self.clazz = clazz
 
@@ -304,6 +310,7 @@ class NoneOr(Union):
     param : :obj:`carta.validation.Parameter`
         The parameter descriptor.
     """
+
     def __init__(self, param):
         options = (
             param,
@@ -325,6 +332,7 @@ class IterableOf(Parameter):
     param : :obj:`carta.validation.Parameter`
         The parameter descriptor.
     """
+
     def __init__(self, param):
         self.param = param
 
@@ -393,9 +401,9 @@ class TupleColor(Parameter):
 
         See :obj:`carta.validation.Parameter.validate` for general information about this method.
         """
-        value = re.sub('\s', '', value)
+        value = re.sub(r'\s', '', value)
 
-        m = re.match('(hsla?|rgba?)\((.*)\)', value)
+        m = re.match(r'(hsla?|rgba?)\((.*)\)', value)
         if m is None:
             raise ValueError(f"{value} is not {self.description}.")
 
@@ -412,12 +420,13 @@ class TupleColor(Parameter):
 
 class Color(Union):
     """Any valid HTML color specification: a 3- or 6-digit hex triplet, an RBG(A) or HSL(A) tuple, or one of the 147 named colors."""
+
     def __init__(self):
         options = (
-            OneOf(*COLORNAMES, lambda v: v.lower()), # Named color
-            String("#[0-9a-f]{6}", re.IGNORECASE), # 6-digit hex
-            String("#[0-9a-f]{3}", re.IGNORECASE), # 3-digit hex
-            TupleColor(), # RGB, RGBA, HSL, HSLA
+            OneOf(*COLORNAMES, lambda v: v.lower()),  # Named color
+            String("#[0-9a-f]{6}", re.IGNORECASE),  # 6-digit hex
+            String("#[0-9a-f]{3}", re.IGNORECASE),  # 3-digit hex
+            TupleColor(),  # RGB, RGBA, HSL, HSLA
         )
         super().__init__(options, "an HTML color specification")
 
@@ -495,7 +504,7 @@ def validate(*vargs):
     """
 
     def decorator(func):
-        kwvargs = {k:v for (k, v) in zip(inspect.getfullargspec(func).args[1:], vargs)}
+        kwvargs = {k: v for (k, v) in zip(inspect.getfullargspec(func).args[1:], vargs)}
         STRIP_OBJ = re.compile(":obj:`(.*)`")
         STRIP_CODE = re.compile("``(.*)``")
         PRESERVE = re.compile("(:obj:`.+?`|``.+?``)")

--- a/carta/validation.py
+++ b/carta/validation.py
@@ -33,7 +33,13 @@ class Parameter:
 
     @property
     def description(self):
-        """A human-readable description of this parameter descriptor."""
+        """A human-readable description of this parameter descriptor.
+
+        Returns
+        -------
+        string
+            The description.
+        """
         return "UNKNOWN"
 
 
@@ -72,6 +78,13 @@ class String(Parameter):
 
     @property
     def description(self):
+        """A human-readable description of this parameter descriptor.
+
+        Returns
+        -------
+        string
+            The description.
+        """
         if self.regex:
             return f"`a string matching` ``{self.regex}``"
         return "a string"
@@ -139,6 +152,13 @@ class Number(Parameter):
 
     @property
     def description(self):
+        """A human-readable description of this parameter descriptor.
+
+        Returns
+        -------
+        string
+            The description.
+        """
         desc = ["a number"]
 
         if self.min is not None:
@@ -166,6 +186,13 @@ class Boolean(Parameter):
 
     @property
     def description(self):
+        """A human-readable description of this parameter descriptor.
+
+        Returns
+        -------
+        string
+            The description.
+        """
         return "a boolean"
 
 
@@ -182,6 +209,13 @@ class NoneParameter(Parameter):
 
     @property
     def description(self):
+        """A human-readable description of this parameter descriptor.
+
+        Returns
+        -------
+        string
+            The description.
+        """
         return "``None``"
 
 
@@ -220,6 +254,13 @@ class OneOf(Parameter):
 
     @property
     def description(self):
+        """A human-readable description of this parameter descriptor.
+
+        Returns
+        -------
+        string
+            The description.
+        """
         return f"one of {', '.join(str(o) for o in self.options)}"
 
 
@@ -264,6 +305,13 @@ class Union(Parameter):
 
     @property
     def description(self):
+        """A human-readable description of this parameter descriptor.
+
+        Returns
+        -------
+        string
+            The description.
+        """
         return self._description or " or ".join(o.description for o in self.options)
 
 
@@ -290,6 +338,13 @@ class Constant(OneOf):
 
     @property
     def description(self):
+        """A human-readable description of this parameter descriptor.
+
+        Returns
+        -------
+        string
+            The description.
+        """
         if self.clazz.__module__ is None or self.clazz.__module__ == str.__class__.__module__:
             fullname = self.clazz.__name__  # Avoid reporting __builtin__
         else:
@@ -346,6 +401,13 @@ class IterableOf(Parameter):
 
     @property
     def description(self):
+        """A human-readable description of this parameter descriptor.
+
+        Returns
+        -------
+        string
+            The description.
+        """
         return f"an iterable of {self.param.description}"
 
 
@@ -415,6 +477,13 @@ class TupleColor(Parameter):
 
     @property
     def description(self):
+        """A human-readable description of this parameter descriptor.
+
+        Returns
+        -------
+        string
+            The description.
+        """
         return "an HTML color tuple"
 
 
@@ -469,6 +538,13 @@ class Evaluate(Parameter):
 
     @property
     def description(self):
+        """A human-readable description of this parameter descriptor.
+
+        Returns
+        -------
+        string
+            The description.
+        """
         args = list(self.args)
         for i, arg in enumerate(args):
             if isinstance(arg, Attr):

--- a/docs/source/carta.rst
+++ b/docs/source/carta.rst
@@ -1,9 +1,6 @@
 carta package
 =============
 
-Submodules
-----------
-
 carta.browser module
 --------------------
 
@@ -12,18 +9,42 @@ carta.browser module
    :undoc-members:
    :show-inheritance:
 
-carta.client module
--------------------
-
-.. automodule:: carta.client
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 carta.constants module
 ----------------------
 
 .. automodule:: carta.constants
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+carta.image module
+------------------
+
+.. automodule:: carta.image
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+carta.protocol module
+---------------------
+
+.. automodule:: carta.protocol
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+carta.session module
+--------------------
+
+.. automodule:: carta.session
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+carta.token module
+------------------
+
+.. automodule:: carta.token
    :members:
    :undoc-members:
    :show-inheritance:
@@ -40,15 +61,6 @@ carta.validation module
 -----------------------
 
 .. automodule:: carta.validation
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-
-Module contents
----------------
-
-.. automodule:: carta
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/carta.rst
+++ b/docs/source/carta.rst
@@ -1,6 +1,14 @@
 carta package
 =============
 
+carta.backend module
+--------------------
+
+.. automodule:: carta.backend
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 carta.browser module
 --------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,7 @@ copyright = '2020, Adrianna Pińska'
 author = 'Adrianna Pińska'
 
 # The full version, including alpha/beta/rc tags
-release = '0.0.1'
+release = '1.0.0-beta'
 
 
 # -- General configuration ---------------------------------------------------
@@ -40,8 +40,8 @@ napoleon_google_docstring = False
 napoleon_use_param = False
 napoleon_use_ivar = True
 
-# This mocks out the external grpc dependency and the protocol buffer files which are only generated when the package is installed
-autodoc_mock_imports = ["grpc", "selenium", "cartaproto"]
+# This mocks out the external dependencies
+autodoc_mock_imports = ["selenium", "requests"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -3,10 +3,8 @@ Introduction
 
 This is a Python-based scripting interface for `CARTA, the Cube Analysis and Rendering Tool for Astronomy <https://cartavis.org/>`_, an astronomical image visualization and analysis tool. More information about CARTA can be found on the main `CARTA documentation <https://carta.readthedocs.io>`_ page.
 
-This scripting wrapper allows the user to execute functions in the CARTA frontend component programmatically, simulating various actions which can be taken through the graphical user interface in the browser. The CARTA backend acts as a proxy, receiving commands from the wrapper through a gRPC service, forwarding them to the frontend through a websocket connection, and relaying responses back to the wrapper.
+This scripting wrapper allows the user to execute functions in the CARTA frontend component programmatically, simulating various actions which can be taken through the graphical user interface in the browser. The CARTA backend acts as a proxy, receiving commands from the wrapper through an HTTP interface, forwarding them to the frontend through a websocket connection, and relaying responses back to the wrapper.
 
 The wrapper provides the user with a high-level API which streamlines certain common tasks and validates function input. The user also has the option of using the low-level interface more directly, to implement functionality which is not yet available in the high-level API. We recommend that users make use of the high-level API whenever possible -- custom low-level commands may break with future changes to the internals of the frontend component.
-
-This document assumes that the user is using CARTA in "User Deployment Mode" (UDM), running the backend component directly on a local host or one accessible through SSH. "Site Deployment Mode" (SDM) support for scripting is under development.
 
 This package is experimental, and only supports POSIX operating systems.

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -56,7 +56,7 @@ Creating a new session
 
 Use the ``create`` method if you want to write a non-interactive script which starts a new session in a headless browser, performs a series of actions, and saves output, with no input from you.
 
-The wrapper automatically parses the session ID from the frontend. If the wrapper also starts the backend process, it parses the frontend URL from the backend output. If you want to connect to an existing backend process, you must provide the frontend URL and the security token.
+The wrapper automatically parses the session ID from the frontend. If the wrapper also starts the backend process, it parses the frontend URL from the backend output. If you want to connect to an existing backend process, you must provide the frontend URL and the security token. You may omit the token if it is included in the URL.
 
 The wrapper can start a backend process on a remote host if your Unix user has the appropriate permissions to ssh to the remote host without entering a password.
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -116,7 +116,7 @@ Changing image properties
 Properties specific to individual images can be accessed through image objects:
 
 .. code-block:: python
-
+    import numpy as np
     from carta.constants import Colormap, Scaling
 
     # change the channel

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -23,45 +23,81 @@ If you want to create browser sessions from the wrapper, you also need to make s
 Connecting to an existing session
 ---------------------------------
 
-Use this option if you want to use scripting to control a CARTA session which you already have open in your browser.
+Use the ``interact`` method if you want to use scripting to control a CARTA session which you already have open in your browser.
 
 .. code-block:: python
     
     from carta.client import Session
+    from carta.token import BackendToken
 
-    session = Session.interact("FRONTEND URL", 1, "SECURITY TOKEN")
+    session = Session.interact("FRONTEND URL", 1, BackendToken("SECURITY TOKEN"))
 
-The frontend URL and security token values must match your running backend process. For simplicity you have the option of using an environment variable, ``CARTA_AUTH_TOKEN``, to run CARTA with a fixed security token. Otherwise, a randomly generated token will be printed by the backend when it starts. The session ID must match the running frontend session -- you can find it by mousing over the status indicator at the top right of the CARTA window in your browser.
+If you have launched a backend directly, the frontend URL and security token must match your running backend process. You have the option of using an environment variable, ``CARTA_AUTH_TOKEN``, to run CARTA with a fixed security token. Otherwise, a randomly generated token will be printed by the backend when it starts. If you include the security token in the URL, you may omit the security token parameter (it will be parsed from the URL automatically).
+
+To connect to a controller instance, you must authenticate to obtain a controller security token. We recommend using the helper functions provided to save the token to a file and load it from a file. You may also be able to copy this token from an existing browser cookie. This is a long-lived refresh token which will be used automatically to obtain access tokens from the controller as required. You will only have to authenticate again when the long-lived token expires. Token lifetime is configured by the host of the controller.
+
+.. code-block:: python
+    
+    from carta.client import Session
+    from carta.protocol import Protocol
+    from carta.token import ControllerToken
+    
+    # Get a refresh token from the controller -- you only have to do this when the token expires
+    # You will be prompted securely for a password
+    # We recommend not automating this in a way that reveals the password!
+    Protocol.request_refresh_token("FRONTEND URL", "USERNAME", "path/to/token")
+
+    session = Session.interact("FRONTEND URL", 1, ControllerToken.from_file("path/to/token"))
+
+The session ID must match the running frontend session -- you can find it by mousing over the status indicator at the top right of the CARTA window in your browser.
 
 Creating a new session
 ----------------------
 
-Use these options if you want to write a non-interactive script which starts a new session in a headless browser (and optionally also a new backend process), performs a series of actions, and saves output, with no input from you.
+Use the ``create`` method if you want to write a non-interactive script which starts a new session in a headless browser, performs a series of actions, and saves output, with no input from you.
 
 The wrapper automatically parses the session ID from the frontend. If the wrapper also starts the backend process, it parses the frontend URL from the backend output. If you want to connect to an existing backend process, you must provide the frontend URL and the security token.
 
 The wrapper can start a backend process on a remote host if your Unix user has the appropriate permissions to ssh to the remote host without entering a password.
 
-To connect to a controller instance, you must obtain a security token for scripting requests from the controller dashboard. Creating the session requires additional authentication. A helper function is provided to assist you in logging into the controller instance and obtaining a long-lived cookie which you can save and use when creating a session. (TODO: actually implement this) 
-
-These commands are further customisable with optional parameters. See the API reference for more information.
-
 .. code-block:: python
     
     from carta.client import Session
+    from carta.token import BackendToken
     from carta.browser import ChromeHeadless
 
     # New session, connect to an existing backend
-    session = Session.create(ChromeHeadless(), "FRONTEND URL", "SECURITY TOKEN")
+    session = Session.create(ChromeHeadless(), "FRONTEND URL", BackendToken("SECURITY TOKEN"))
 
     # New session, start local backend
     session = Session.start_and_create(ChromeHeadless())
 
     # New session, start remote backend
     session = Session.start_and_create(ChromeHeadless(), remote_host="REMOTE HOSTNAME OR IP")
+
+To connect to a controller instance, you must authenticate (synchronously) to obtain a controller security token. We recommend using the helper functions provided to save the token to a file and to load it from a file when you use it.
+
+.. code-block:: python
+
+    from carta.protocol import Protocol
+
+    # Get a refresh token from the controller -- you only have to do this when the token expires
+    # You will be prompted securely for a password
+    # We recommend not automating this in a way that reveals the password!
+    Protocol.request_refresh_token("FRONTEND URL", "USERNAME", "path/to/token")
     
-    # New session, connect to an existing controller (a cookie is needed for authentication)
-    session = Session.create(ChromeHeadless(), "FRONTEND URL", "SECURITY TOKEN", "path/to/cookie/file")
+This is a long-lived refresh token which will be used automatically to obtain access tokens from the controller as required. You will only have to authenticate again when the long-lived token expires. Token lifetime is configured by the host of the controller. 
+
+.. code-block:: python
+
+    from carta.client import Session
+    from carta.browser import ChromeHeadless
+    from carta.token import ControllerToken
+    
+    # New session, connect to an existing controller
+    session = Session.create(ChromeHeadless(), "FRONTEND URL", ControllerToken.from_file("path/to/token"))
+    
+These commands are further customisable with optional parameters. See the API reference for more information.
 
 Opening and appending images
 ----------------------------

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -64,16 +64,16 @@ The wrapper can start a backend process on a remote host if your Unix user has t
     
     from carta.client import Session
     from carta.token import BackendToken
-    from carta.browser import ChromeHeadless
+    from carta.browser import Chrome
 
     # New session, connect to an existing backend
-    session = Session.create(ChromeHeadless(), "FRONTEND URL", BackendToken("SECURITY TOKEN"))
+    session = Session.create(Chrome(), "FRONTEND URL", BackendToken("SECURITY TOKEN"))
 
     # New session, start local backend
-    session = Session.start_and_create(ChromeHeadless())
+    session = Session.start_and_create(Chrome())
 
     # New session, start remote backend
-    session = Session.start_and_create(ChromeHeadless(), remote_host="REMOTE HOSTNAME OR IP")
+    session = Session.start_and_create(Chrome(), remote_host="REMOTE HOSTNAME OR IP")
 
 To connect to a controller instance, you must authenticate (synchronously) to obtain a controller security token. We recommend using the helper functions provided to save the token to a file and to load it from a file when you use it.
 
@@ -91,11 +91,11 @@ This is a long-lived refresh token which will be used automatically to obtain ac
 .. code-block:: python
 
     from carta.client import Session
-    from carta.browser import ChromeHeadless
+    from carta.browser import Chrome
     from carta.token import ControllerToken
     
     # New session, connect to an existing controller
-    session = Session.create(ChromeHeadless(), "FRONTEND URL", ControllerToken.from_file("path/to/token"))
+    session = Session.create(Chrome(), "FRONTEND URL", ControllerToken.from_file("path/to/token"))
     
 These commands are further customisable with optional parameters. See the API reference for more information.
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -20,15 +20,6 @@ You need access either to a CARTA backend executable, on the local host or on a 
 
 If you want to create browser sessions from the wrapper, you also need to make sure that your desired browser is installed, together with a corresponding web driver. At present only Chrome (or Chromium) can be used for headless sessions.
 
-.. warning::
-    At time of writing, the Snap package of Chromium has a bug which prevents WebGL from working in headless mode.
-
-    Our recommended workaround is to use Chrome installed from `Google's website <https://www.google.com/chrome/>`_ together with an appropriate version of Chromedriver installed from `the Chromedriver website <https://chromedriver.chromium.org/downloads>`_ (the Snap ``chromedriver`` executable may not work even if the version appears to be compatible).
-
-    Your distro may also have an alternative Chromium package available.
-
-    Selenium should automatically find the Chrome or Chromium executable in the default system install location, and the Chromedriver executable if it is in your path, but if you have multiple versions installed in parallel you may need to specify paths explicitly when creating the :obj:`carta.browser.Chrome` object.
-
 Connecting to an existing session
 ---------------------------------
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -36,7 +36,7 @@ Use the ``interact`` method if you want to use scripting to control a CARTA sess
 
 .. code-block:: python
     
-    from carta.client import Session
+    from carta.session import Session
     from carta.token import BackendToken
 
     session = Session.interact("FRONTEND URL", 1, BackendToken("SECURITY TOKEN"))
@@ -47,7 +47,7 @@ To connect to a controller instance, you must authenticate to obtain a controlle
 
 .. code-block:: python
     
-    from carta.client import Session
+    from carta.session import Session
     from carta.protocol import Protocol
     from carta.token import ControllerToken
     
@@ -71,7 +71,7 @@ The wrapper can start a backend process on a remote host if your Unix user has t
 
 .. code-block:: python
     
-    from carta.client import Session
+    from carta.session import Session
     from carta.token import BackendToken
     from carta.browser import Chrome
 
@@ -99,7 +99,7 @@ This is a long-lived refresh token which will be used automatically to obtain ac
 
 .. code-block:: python
 
-    from carta.client import Session
+    from carta.session import Session
     from carta.browser import Chrome
     from carta.token import ControllerToken
     

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -20,6 +20,15 @@ You need access either to a CARTA backend executable, on the local host or on a 
 
 If you want to create browser sessions from the wrapper, you also need to make sure that your desired browser is installed, together with a corresponding web driver. At present only Chrome (or Chromium) can be used for headless sessions.
 
+.. warning::
+    At time of writing, the Snap package of Chromium has a bug which prevents WebGL from working in headless mode.
+
+    Our recommended workaround is to use Chrome installed from `Google's website <https://www.google.com/chrome/>`_ together with an appropriate version of Chromedriver installed from `the Chromedriver website <https://chromedriver.chromium.org/downloads>`_ (the Snap ``chromedriver`` executable may not work even if the version appears to be compatible).
+
+    Your distro may also have an alternative Chromium package available.
+
+    Selenium should automatically find the Chrome or Chromium executable in the default system install location, and the Chromedriver executable if it is in your path, but if you have multiple versions installed in parallel you may need to specify paths explicitly when creating the :obj:`carta.browser.Chrome` object.
+
 Connecting to an existing session
 ---------------------------------
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -116,6 +116,7 @@ Changing image properties
 Properties specific to individual images can be accessed through image objects:
 
 .. code-block:: python
+
     import numpy as np
     from carta.constants import Colormap, Scaling
 

--- a/scripts/style_check.sh
+++ b/scripts/style_check.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Check for PEP8 code style violations, but ignore long lines
+
+pycodestyle carta/*.py | grep -v E501

--- a/scripts/style_fix.sh
+++ b/scripts/style_fix.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Fix PEP8 code style violations, but ignore long lines
+
+echo "Fixing issues automatically (except long lines)..."
+
+autopep8 --in-place --ignore E501 carta/*.py
+
+# Check for PEP8 code style violations, but ignore long lines
+
+echo "Outstanding issues (except long lines):"
+
+pycodestyle carta/*.py | grep -v E501

--- a/setup.py
+++ b/setup.py
@@ -1,51 +1,18 @@
-import os
-import re
 import setuptools
-from distutils.command.build_py import build_py as build_py_orig
-
-class BuildGrpc(setuptools.Command):
-    def initialize_options(self):
-        pass
-
-    def finalize_options(self):
-        pass
-
-    def run(self):
-        import grpc_tools.protoc
-
-        grpc_tools.protoc.main([
-            'grpc_tools.protoc',
-            '-Icarta-scripting-grpc',
-            '--python_out=cartaproto/',
-            '--grpc_python_out=cartaproto/',
-            'carta-scripting-grpc/carta_service.proto'
-        ])
-        
-        # There seriously isn't a better way to fix this relative import as of time of writing
-        with open('cartaproto/carta_service_pb2_grpc.py') as f:
-            data = f.read()
-        data = re.sub("^import carta_service_pb2", "from . import carta_service_pb2", data, flags=re.MULTILINE)
-        with open('cartaproto/carta_service_pb2_grpc.py', 'w') as f:
-            f.write(data)
-        
-class BuildPy (build_py_orig):
-    def run(self):
-        self.run_command('build_grpc')
-        super(BuildPy, self).run()
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(
     name="carta",
-    version="0.0.1",
+    version="1.0.0-beta",
     author="Adrianna Pińska",
     author_email="adrianna.pinska@gmail.com",
     description="CARTA scripting wrapper written in Python",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/idia-astro/carta-python",
-    packages=setuptools.find_packages(),
+    packages=["carta"],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
@@ -54,14 +21,6 @@ setuptools.setup(
     ],
     python_requires='>=3.6',
     install_requires=[
-        "grpcio>=1.26.0",
+        "requests",
     ],
-    setup_requires=[
-        "google-api-python-client>=1.12.4",
-        "grpcio-tools>=1.26.0",
-    ],
-    cmdclass={
-        "build_py": BuildPy,
-        "build_grpc": BuildGrpc,
-    },
 )


### PR DESCRIPTION
This is an update of the wrapper to use the new HTTP scripting API.

This PR should be merged at the same time as the companion PRs in the [backend](https://github.com/CARTAvis/carta-backend/pull/1022), [frontend](https://github.com/CARTAvis/carta-frontend/pull/1785), [protocol buffers](https://github.com/CARTAvis/carta-protobuf/pull/65), [controller](https://github.com/CARTAvis/carta-controller/pull/110) and [website](https://github.com/CARTAvis/CARTAvis.github.io/pull/18).