### PR TITLE
Missing wheel package causes error in minimalist Python venv

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,4 +23,7 @@ setuptools.setup(
     install_requires=[
         "requests",
     ],
+    setup_requires=[
+        "wheel",
+    ],
 )


### PR DESCRIPTION
When starting from a minimalist virtual environment, trying to install the package as instructed generates an error due to wheel not being installed:
```
(carta-python-venv) ubuntu@carta-dave:~/carta-python$ pip install .
Processing /home/ubuntu/carta-python
Collecting requests
  Downloading requests-2.27.1-py2.py3-none-any.whl (63 kB)
     |████████████████████████████████| 63 kB 584 kB/s 
Collecting idna<4,>=2.5; python_version >= "3"
  Downloading idna-3.3-py3-none-any.whl (61 kB)
     |████████████████████████████████| 61 kB 387 kB/s 
Collecting charset-normalizer~=2.0.0; python_version >= "3"
  Downloading charset_normalizer-2.0.12-py3-none-any.whl (39 kB)
Collecting urllib3<1.27,>=1.21.1
  Downloading urllib3-1.26.8-py2.py3-none-any.whl (138 kB)
     |████████████████████████████████| 138 kB 97.0 MB/s 
Collecting certifi>=2017.4.17
  Downloading certifi-2021.10.8-py2.py3-none-any.whl (149 kB)
     |████████████████████████████████| 149 kB 109.3 MB/s 
Building wheels for collected packages: carta
  Building wheel for carta (setup.py) ... error
  ERROR: Command errored out with exit status 1:
   command: /home/ubuntu/carta-python-venv/bin/python3 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-req-build-sm7rvequ/setup.py'"'"'; __file__='"'"'/tmp/pip-req-build-sm7rvequ/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /tmp/pip-wheel-lu1y3ik3
       cwd: /tmp/pip-req-build-sm7rvequ/
  Complete output (8 lines):
  /home/ubuntu/carta-python-venv/lib/python3.8/site-packages/setuptools/dist.py:473: UserWarning: Normalizing '1.0.0-beta' to '1.0.0b0'
    warnings.warn(
  usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: setup.py --help [cmd1 cmd2 ...]
     or: setup.py --help-commands
     or: setup.py cmd --help
  
  error: invalid command 'bdist_wheel'
  ----------------------------------------
  ERROR: Failed building wheel for carta
  Running setup.py clean for carta
Failed to build carta
Installing collected packages: idna, charset-normalizer, urllib3, certifi, requests, carta
    Running setup.py install for carta ... done
Successfully installed carta-1.0.0b0 certifi-2021.10.8 charset-normalizer-2.0.12 idna-3.3 requests-2.27.1 urllib3-1.26.8
```

My environment:
```
(venv4) ubuntu@carta-dave:~/carta-python$ python --version
Python 3.8.10
(venv4) ubuntu@carta-dave:~$ pip list
Package       Version
------------- -------
pip           20.0.2 
pkg-resources 0.0.0  
setuptools    44.0.0
```