### PR TITLE
Add simplejson as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setuptools.setup(
     python_requires='>=3.6',
     install_requires=[
         "requests",
+        "simplejson",
     ],
     setup_requires=[
         "wheel",


### PR DESCRIPTION
`setup.py` did not include `simplejson` as a requirement.  It is however used by `carta/protocol.py`.