### PR TITLE
Add handling for 501 status

### DIFF
--- a/carta/protocol.py
+++ b/carta/protocol.py
@@ -354,6 +354,7 @@ class Protocol:
             403: "Could not authenticate.",
             404: f"No session with ID {session_id} could be found.",
             500: "An internal error occurred, or the client cancelled the request.",
+            501: "Scripting is not enabled in the backend.",
         }
 
         if response.status_code != 200:


### PR DESCRIPTION
There's a companion PR in the backend for returning 501 instead of 403 for disabled features. This means that we'll be able to distinguish between an authentication failure and scripting being disabled. This PR adds an explicit descriptive message for this error status.