### PR TITLE
Automatically try to convert the session ID to int

### DIFF
--- a/carta/session.py
+++ b/carta/session.py
@@ -11,7 +11,7 @@ import base64
 from .image import Image
 from .constants import CoordinateSystem, LabelType, BeamType, PaletteColor, Overlay
 from .protocol import Protocol
-from .util import logger, Macro, split_action_path, CartaScriptingException
+from .util import logger, Macro, split_action_path, CartaScriptingException, CartaBadID
 from .validation import validate, String, Number, Color, Constant, Boolean, NoneOr, OneOf
 
 
@@ -62,7 +62,7 @@ class Session:
         frontend_url : string
             The frontend URL of the CARTA instance.
         session_id : integer
-            The ID of an existing CARTA frontend session.
+            The ID of an existing CARTA frontend session. You may supply this as a string of digits; it will be converted to an integer automatically.
         token : :obj:`carta.token.Token`, optional
             The security token used by the CARTA instance. You may omit this if the URL contains a token.
         debug_no_auth : boolean, optional
@@ -75,6 +75,8 @@ class Session:
 
         Raises
         ------
+        CartaBadID
+            If the ID provided cannot be converted to an integer
         CartaBadToken
             If an invalid token was provided.
         CartaBadUrl
@@ -82,6 +84,11 @@ class Session:
         CartaBadSession
             If the session object could not be created.
         """
+        try:
+            session_id = int(session_id)
+        except ValueError:
+            raise CartaBadID(f"Session ID '{session_id}' is not a number.")
+
         return cls(session_id, Protocol(frontend_url, token, debug_no_auth=debug_no_auth))
 
     @classmethod

--- a/carta/util.py
+++ b/carta/util.py
@@ -20,6 +20,11 @@ class CartaBadSession(CartaScriptingException):
     pass
 
 
+class CartaBadID(CartaScriptingException):
+    """A session ID is invalid."""
+    pass
+
+
 class CartaBadToken(CartaScriptingException):
     """A token has expired or is invalid."""
     pass

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="carta",
-    version="1.1.3",
+    version="1.1.4",
     author="Adrianna Pińska",
     author_email="adrianna.pinska@gmail.com",
     description="CARTA scripting wrapper written in Python",


### PR DESCRIPTION
This prevents requests from failing if the user supplies a string instead of an integer (a mistake I have made several times).