### PR TITLE
Add fallback for entries with no values; aggregate HISTORY, COMMENT and blank entries

### DIFF
--- a/carta/image.py
+++ b/carta/image.py
@@ -155,7 +155,7 @@ class Image:
             The header of the image, with field names as keys. T or F string values are automatically converted to booleans.
         """
         raw_header = self.get_value("frameInfo.fileInfoExtended.headerEntries")
-        header = {e["name"]: e.get("numericValue", e["value"]) for e in raw_header}
+        header = {e["name"]: e.get("numericValue", e.get("value", None)) for e in raw_header}
         for k, v in header.items():
             if v == 'T':
                 header[k] = True

--- a/carta/image.py
+++ b/carta/image.py
@@ -151,16 +151,61 @@ class Image:
 
         Returns
         -------
-        dict of string to string, integer, float or boolean
-            The header of the image, with field names as keys. T or F string values are automatically converted to booleans.
+        dict of string to string, integer, float, boolean, ``None`` or list of strings
+            The header of the image, with field names as keys. T or F string values are automatically converted to booleans. ``HISTORY``, ``COMMENT`` and blank keyword entries are aggregated into single entries with list values and with ``'HISTORY'``, ``'COMMENT'`` and ``''`` as keys, respectively. An entry in the history list which begins with ``'>'`` will be concatenated with the previous entry. Any other header entries with no values are given values of ``None``.
         """
         raw_header = self.get_value("frameInfo.fileInfoExtended.headerEntries")
-        header = {e["name"]: e.get("numericValue", e.get("value", None)) for e in raw_header}
-        for k, v in header.items():
-            if v == 'T':
-                header[k] = True
-            elif v == 'F':
-                header[k] = False
+
+        header = {}
+
+        history = []
+        comment = []
+        blank = []
+
+        def header_value(raw_entry):
+            try:
+                return raw_entry["numericValue"]
+            except KeyError:
+                try:
+                    value = raw_entry["value"]
+                    if value == 'T':
+                        return True
+                    if value == 'F':
+                        return False
+                    return value
+                except KeyError:
+                    return None
+
+        for raw_entry in raw_header:
+            name = raw_entry["name"]
+
+            if name.startswith("HISTORY "):
+                line = name[8:]
+                if line.startswith(">"):
+                    history[-1] = history[-1] + line[1:]
+                else:
+                    history.append(line)
+                continue
+
+            if name.startswith("COMMENT "):
+                comment.append(name[8:])
+                continue
+
+            if name.startswith(" " * 8):
+                blank.append(name[8:])
+                continue
+
+            header[name] = header_value(raw_entry)
+
+        if history:
+            header["HISTORY"] = history
+
+        if comment:
+            header["COMMENT"] = comment
+
+        if blank:
+            header[""] = blank
+
         return header
 
     @property

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="carta",
-    version="1.1.4",
+    version="1.1.5",
     author="Adrianna Pińska",
     author_email="adrianna.pinska@gmail.com",
     description="CARTA scripting wrapper written in Python",


### PR DESCRIPTION
Fixes #44. What was initially a simple fix became more complex when I realised that `HISTORY` entries can be duplicates, which means that they can't be used as dictionary keys (and it's also not very useful conceptually to do this). I have done something similar to [what Astropy does](https://docs.astropy.org/en/stable/io/fits/usage/headers.html#comment-history-and-blank-keywords) and aggregated `HISTORY`, `COMMENT` and blank keyword entries into single entries with list values. Additionally, I use the `>` continuation marker in the `HISTORY` entries to concatenate wrapped lines back together.

I have kept the `None` fallback in case we encounter other entries with no values (I don't know if that's legal FITS, but if it isn't, that doesn't mean someone isn't going to do it).