### PR TITLE
Confluence/polarization

### DIFF
--- a/carta/constants.py
+++ b/carta/constants.py
@@ -113,3 +113,24 @@ class ContourDashMode:
     NONE = "None"
     DASHED = "Dashed"
     NEGATIVE_ONLY = "NegativeOnly"
+
+
+class Polarization:
+    """Polarizations, corresponding to the POLARIZATIONS enum in the frontend."""
+    YX = -8
+    XY = -7
+    YY = -6
+    XX = -5
+    LR = -4
+    RL = -3
+    LL = -2
+    RR = -1
+    I = 1
+    Q = 2
+    U = 3
+    V = 4
+    PTOTAL = 13
+    PLINEAR = 14
+    PFTOTAL = 15
+    PFLINEAR = 16
+    PANGLE = 17

--- a/carta/image.py
+++ b/carta/image.py
@@ -342,7 +342,7 @@ class Image:
 
     # NAVIGATION
 
-    @validate(Evaluate(Number, 0, Attr("depth"), Number.INCLUDE_MIN), Evaluate(Number, 0, Attr("num_stokes"), Number.INCLUDE_MIN), Boolean())
+    @validate(Evaluate(Number, 0, Attr("depth"), Number.INCLUDE_MIN), Evaluate(Number, 1, Attr("num_stokes")), Boolean())
     def set_channel_stokes(self, channel=None, stokes=None, recursive=True):
         """Set the channel and/or Stokes.
 

--- a/carta/image.py
+++ b/carta/image.py
@@ -309,6 +309,11 @@ class Image:
 
         This includes Stokes parameters, correlations, and computed components.
 
+        Parameters
+        ----------
+        polarization: {0}
+            The polarization to check.
+
         Returns
         -------
         boolean

--- a/carta/image.py
+++ b/carta/image.py
@@ -303,24 +303,6 @@ class Image:
         """
         return self.get_value("polarizations")
 
-    @validate(Constant(Polarization))
-    def has_polarization(self, polarization):
-        """Check whether a polarization is available.
-
-        This includes Stokes parameters, correlations, and computed components.
-
-        Parameters
-        ----------
-        polarization: {0}
-            The polarization to check.
-
-        Returns
-        -------
-        boolean
-            Whether the polarization is available.
-        """
-        return polarization in self.polarizations
-
     # SELECTION
 
     def make_active(self):

--- a/carta/image.py
+++ b/carta/image.py
@@ -374,24 +374,39 @@ class Image:
 
     # NAVIGATION
 
-    @validate(Evaluate(Number, 0, Attr("depth"), Number.INCLUDE_MIN), Evaluate(OneOf, Attrs("polarizations")), Boolean())
-    def set_channel_polarization(self, channel=None, polarization=None, recursive=True):
-        """Set the channel and/or polarization.
+    @validate(Evaluate(Number, 0, Attr("depth"), Number.INCLUDE_MIN), Boolean())
+    def set_channel(self, channel, recursive=True):
+        """Set the channel.
 
         Parameters
         ----------
         channel : {0}
             The desired channel. Defaults to the current channel.
-        polarization : {1}
-            The desired polarization. Defaults to the current polarization.
-        recursive : {2}
+        recursive : {1}
             Whether to perform the same change on all spectrally matched images. Defaults to True.
         """
         if channel is None:
             channel = self.get_value("requiredChannel")
 
-        if polarization is None:
-            polarization = self.get_value("requiredPolarization")
+        polarization = self.get_value("requiredPolarization")
+
+        if polarization < Polarization.PTOTAL:
+            polarization = self.polarizations.index(polarization)
+
+        self.call_action("setChannels", channel, polarization, recursive)
+
+    @validate(Evaluate(OneOf, Attrs("polarizations")), Boolean())
+    def set_polarization(self, polarization, recursive=True):
+        """Set the polarization.
+
+        Parameters
+        ----------
+        polarization : {0}
+            The desired polarization. Defaults to the current polarization.
+        recursive : {1}
+            Whether to perform the same change on all spectrally matched images. Defaults to True.
+        """
+        channel = self.get_value("requiredChannel")
 
         if polarization < Polarization.PTOTAL:
             polarization = self.polarizations.index(polarization)

--- a/carta/validation.py
+++ b/carta/validation.py
@@ -138,18 +138,24 @@ class Number(Parameter):
         if self.min is not None:
             if self.min_included:
                 if value < self.min:
-                    raise ValueError(f"{value} is smaller than minimum value {self.min}.")
+                    raise ValueError(f"{value} is smaller than lower bound {self.min}, but must be greater or equal.")
             else:
-                if value <= self.min:
-                    raise ValueError(f"{value} is smaller than or equal to minimum value {self.min}.")
+                if value == self.min:
+                    cmp_str = "equal to"
+                if value < self.min:
+                    cmp_str = "smaller than"
+                raise ValueError(f"{value} is {cmp_str} lower bound {self.min}, but must be greater.")
 
         if self.max is not None:
             if self.max_included:
                 if value > self.max:
-                    raise ValueError(f"{value} is greater than maximum value {self.max}.")
+                    raise ValueError(f"{value} is greater than upper bound {self.max}, but must be smaller or equal.")
             else:
-                if value >= self.max:
-                    raise ValueError(f"{value} is greater than or equal to maximum value {self.max}.")
+                if value == self.max:
+                    cmp_str = "equal to"
+                if value > self.max:
+                    cmp_str = "greater than"
+                raise ValueError(f"{value} is {cmp_str} upper bound {self.max}, but must be smaller.")
 
     @property
     def description(self):

--- a/carta/validation.py
+++ b/carta/validation.py
@@ -578,7 +578,7 @@ class Evaluate(Parameter):
         """
         args = list(self.args)
         for i, arg in enumerate(args):
-            if isinstance(arg, Attr):
+            if isinstance(arg, Attr) or isinstance(arg, Attrs):
                 args[i] = f"self.{arg}"
 
         # This is a bit magic, and relies on the lack of any kind of type checking in the constructors

--- a/carta/validation.py
+++ b/carta/validation.py
@@ -141,10 +141,9 @@ class Number(Parameter):
                     raise ValueError(f"{value} is smaller than lower bound {self.min}, but must be greater or equal.")
             else:
                 if value == self.min:
-                    cmp_str = "equal to"
+                    raise ValueError(f"{value} is equal to lower bound {self.min}, but must be greater.")
                 if value < self.min:
-                    cmp_str = "smaller than"
-                raise ValueError(f"{value} is {cmp_str} lower bound {self.min}, but must be greater.")
+                    raise ValueError(f"{value} is smaller than lower bound {self.min}, but must be greater.")
 
         if self.max is not None:
             if self.max_included:
@@ -152,10 +151,9 @@ class Number(Parameter):
                     raise ValueError(f"{value} is greater than upper bound {self.max}, but must be smaller or equal.")
             else:
                 if value == self.max:
-                    cmp_str = "equal to"
+                    raise ValueError(f"{value} is equal to upper bound {self.max}, but must be smaller.")
                 if value > self.max:
-                    cmp_str = "greater than"
-                raise ValueError(f"{value} is {cmp_str} upper bound {self.max}, but must be smaller.")
+                    raise ValueError(f"{value} is greater than upper bound {self.max}, but must be smaller.")
 
     @property
     def description(self):

--- a/scripts/style_check.sh
+++ b/scripts/style_check.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-# Check for PEP8 code style violations, but ignore long lines
+# Check for PEP8 code style violations, but ignore long lines and ambiguous variable names
 
-pycodestyle carta/*.py | grep -v E501
+pycodestyle --ignore=E501,E741 carta/*.py

--- a/scripts/style_fix.sh
+++ b/scripts/style_fix.sh
@@ -2,12 +2,12 @@
 
 # Fix PEP8 code style violations, but ignore long lines
 
-echo "Fixing issues automatically (except long lines)..."
+echo "Fixing issues automatically..."
 
 autopep8 --in-place --ignore E501 carta/*.py
 
-# Check for PEP8 code style violations, but ignore long lines
+# Check for PEP8 code style violations, but ignore long lines and ambiguous variable names
 
-echo "Outstanding issues (except long lines):"
+echo "Outstanding issues:"
 
-pycodestyle carta/*.py | grep -v E501
+pycodestyle --ignore=E501,E741 carta/*.py


### PR DESCRIPTION
Fixes #51. Any available polarization can be set (always by its numeric value). Keyword aliases are provided through a helper class. A list of available polarizations can be retrieved, and it can be queried by keyword. `polarizations` includes computed polarizations; `num_polarizations` does not.

Examples:

    from carta.constants import Polarization
    img.polarizations
    img.num_polarizations
    img.has_polarization(Polarization.Q)
    img.set_channel_polarization(polarization=Polarization.Q)
    img.set_channel_polarization(polarization=2)
    img.set_channel_polarization(polarization=Polarization.PANGLE)
    img.set_channel_polarization(polarization=17)

Future enhancement (in a separate issue): add a wrapper for return values (like `polarizations`) so that they are displayed as keywords rather than literals. For now the user will see the underlying integer values.

Possible future enhancement: set a (non-computed) polarization by index? Would this be useful?