### PR TITLE
Use a conditional import for Hashable for compatibility with Python >= 3.10

### DIFF
--- a/carta/validation.py
+++ b/carta/validation.py
@@ -3,7 +3,11 @@
 import re
 import functools
 import inspect
-from collections import Hashable
+
+try:
+    from collections.abc import Hashable
+except ImportError:
+    from collections import Hashable
 
 from .util import CartaValidationFailed
 


### PR DESCRIPTION
Fixes #66.