### PR TITLE
Functionality for starting the backend and connecting to the default (interactive) session

### DIFF
--- a/carta/backend.py
+++ b/carta/backend.py
@@ -25,6 +25,8 @@ class Backend:
         If this is set, an attempt will be made to start the backend over ``ssh`` on this host.
     token : :obj:`carta.token.BackendToken`
         If this is set, this will be used as the security token and no attempt will be made to parse the token from the backend output.
+    frontend_url_timeout : integer
+        How long to keep checking the output for the frontend URL. Default: 10 seconds.
     session_creation_timeout : integer
         How long to keep checking the output for a default session ID. If this is set to zero (which is the default), no attempt is made to parse a session ID from the output. The calling function should set this to a non-zero value if parsing the session ID is required.
 
@@ -44,6 +46,8 @@ class Backend:
         Error output of the backend process, split into lines, terminated by newline characters.
     last_session_id : integer
         The ID of the last session connected to this backend process, parsed from the process output. This is likely to be the default session automatically created in the user's browser on startup, if this functionality was not suppressed with the ``--no_browser`` flag. This value is used by the :obj:`carta.session.Session.start_and_interact` method, which connects to this default session. It is not used by the session creation methods which use a wrapper-controlled headless browser, as those parse the session ID from the browser session.
+    frontend_url_timeout : integer
+        How long to keep checking the output for the frontend URL.
     session_creation_timeout : integer
         How long to keep checking the output for a default session ID. If this is set to zero, no attempt is made to parse a session ID from the output.
 
@@ -57,7 +61,7 @@ class Backend:
     FRONTEND_URL_NO_AUTH = re.compile(r"CARTA is accessible at (http://(.*?):\d+.*)")
     SESSION_ID = re.compile(r"Session (\d+) \[[\d.]+\] Connected.")
 
-    def __init__(self, params, executable_path="carta", remote_host=None, token=None, session_creation_timeout=0):
+    def __init__(self, params, executable_path="carta", remote_host=None, token=None, frontend_url_timeout=10, session_creation_timeout=0):
         self.proc = None
         self.frontend_url = None
         self.token = token
@@ -65,6 +69,7 @@ class Backend:
         self.output = []
         self.errors = []
         self.last_session_id = None
+        self.frontend_url_timeout = frontend_url_timeout
         self.session_creation_timeout = session_creation_timeout
 
         ssh_cmd = ("ssh", "-tt", remote_host) if remote_host is not None else tuple()
@@ -90,21 +95,30 @@ class Backend:
         self.proc = subprocess.Popen(self.cmd, stdout=subprocess.PIPE, cwd=pathlib.Path.home(), preexec_fn=os.setpgrp)
         os.set_blocking(self.proc.stdout.fileno(), False)
 
-        time.sleep(1)
-        self.update_output()
-
-        if self.proc.poll() is not None:
-            return False
-
         frontend_url_re = self.FRONTEND_URL if not self.debug_no_auth else self.FRONTEND_URL_NO_AUTH
+        token_string = None
 
-        for line in self.output:
-            m = frontend_url_re.search(line)
-            if m:
-                self.frontend_url, token_string = m.groups()
+        start = time.time()
+
+        while self.frontend_url is None:
+            if time.time() - start > self.frontend_url_timeout:
                 break
 
-        if self.token is None and not self.debug_no_auth:
+            # Check for new output
+            self.update_output()
+
+            if self.proc.poll() is not None:
+                return False
+
+            for line in self.output:
+                m = frontend_url_re.search(line)
+                if m:
+                    self.frontend_url, token_string = m.groups()
+                    break
+
+            time.sleep(1)
+
+        if token_string is not None and self.token is None and not self.debug_no_auth:
             self.token = BackendToken(token_string)
 
         # Only try to parse the session ID if it has been requested
@@ -117,6 +131,9 @@ class Backend:
 
                 # Check for new output
                 self.update_output()
+
+                if self.proc.poll() is not None:
+                    return False
 
                 for line in self.output:
                     m = self.SESSION_ID.search(line)

--- a/carta/browser.py
+++ b/carta/browser.py
@@ -98,7 +98,7 @@ class Browser:
 
         return Session(session_id, protocol, browser=self, backend=backend)
 
-    def new_session_with_backend(self, executable_path="carta", remote_host=None, params=tuple(), timeout=10, token=None):
+    def new_session_with_backend(self, executable_path="carta", remote_host=None, params=tuple(), timeout=10, token=None, frontend_url_timeout=10):
         """Create a new session after launching a new backend process.
 
         You can use :obj:`carta.session.Session.start_and_create`, which wraps this method. This method starts a backend process, parses the frontend URL from the output, and calls :obj:`carta.browser.Browser.new_session_from_url`.
@@ -115,6 +115,8 @@ class Browser:
             The number of seconds to spend parsing the frontend for connection information. 10 seconds by default.
         token : :obj:`carta.token.BackendToken`, optional
             The security token to use. Parsed from the backend output by default.
+        frontend_url_timeout : integer
+            How long to keep checking the backend output for the frontend URL. Default: 10 seconds.
 
         Returns
         -------
@@ -131,7 +133,7 @@ class Browser:
             If the session object could not be created.
         """
 
-        backend = Backend(("--no_browser", "--enable_scripting", *params), executable_path, remote_host, token)
+        backend = Backend(("--no_browser", "--enable_scripting", *params), executable_path, remote_host, token, frontend_url_timeout=frontend_url_timeout, session_creation_timeout=0)
         if not backend.start():
             self.exit(f"CARTA backend exited unexpectedly:\n{''.join(backend.errors)}")
 

--- a/carta/session.py
+++ b/carta/session.py
@@ -95,7 +95,7 @@ class Session:
         return cls(session_id, Protocol(frontend_url, token, debug_no_auth=debug_no_auth), backend=backend)
 
     @classmethod
-    def start_and_interact(cls, executable_path="carta", remote_host=None, params=tuple(), token=None, session_creation_timeout=10):
+    def start_and_interact(cls, executable_path="carta", remote_host=None, params=tuple(), token=None, frontend_url_timeout=10, session_creation_timeout=10):
         """Start a new CARTA backend instance and interact with the default CARTA frontend session which is created automatically in the user's browser. This method cannot be used with a CARTA controller instance.
 
         Parameters
@@ -108,8 +108,10 @@ class Session:
             Additional parameters to be passed to the backend process. By default scripting is enabled. The parameters are appended to the end of the command, so a positional parameter for a data directory can be included.
         token : :obj:`carta.token.Token`, optional
             The security token to use. Parsed from the backend output by default.
+        frontend_url_timeout : integer
+            How long to keep checking the backend output for the frontend URL. Default: 10 seconds.
         session_creation_timeout : integer
-            How long to keep checking the output for a default session ID. 10 seconds by default.
+            How long to keep checking the output for a default session ID. Default: 10 seconds.
 
         Returns
         -------
@@ -127,7 +129,7 @@ class Session:
         CartaBadSession
             If the session object could not be created.
         """
-        backend = Backend(("--enable_scripting", *params), executable_path, remote_host, token, session_creation_timeout=session_creation_timeout)
+        backend = Backend(("--enable_scripting", *params), executable_path, remote_host, token, frontend_url_timeout, session_creation_timeout)
         if not backend.start():
             raise CartaBadSession(f"CARTA backend exited unexpectedly:\n{''.join(backend.errors)}")
 
@@ -175,7 +177,7 @@ class Session:
         return browser.new_session_from_url(frontend_url, token, backend=None, timeout=timeout, debug_no_auth=debug_no_auth)
 
     @classmethod
-    def start_and_create(cls, browser, executable_path="carta", remote_host=None, params=tuple(), timeout=10, token=None):
+    def start_and_create(cls, browser, executable_path="carta", remote_host=None, params=tuple(), timeout=10, token=None, frontend_url_timeout=10):
         """Start a new CARTA backend instance and create a new session. This method cannot be used with a CARTA controller instance (which already starts and stops backend instances for the user on demand).
 
         Parameters
@@ -192,6 +194,8 @@ class Session:
             The number of seconds to spend parsing the frontend for connection information. 10 seconds by default.
         token : :obj:`carta.token.Token`, optional
             The security token to use. Parsed from the backend output by default.
+        frontend_url_timeout : integer
+            How long to keep checking the backend output for the frontend URL. Default: 10 seconds.
 
         Returns
         -------
@@ -207,7 +211,7 @@ class Session:
         CartaBadSession
             If the session object could not be created.
         """
-        return browser.new_session_with_backend(executable_path, remote_host, params, timeout, token)
+        return browser.new_session_with_backend(executable_path, remote_host, params, timeout, token, frontend_url_timeout)
 
     def __repr__(self):
         return f"Session(session_id={self.session_id}, uri={self._protocol.frontend_url})"

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -23,8 +23,8 @@ You need access either to a CARTA backend executable, on the local host or on a 
 
 If you want to create browser sessions from the wrapper, you also need to make sure that your desired browser is installed, together with a corresponding web driver. At present only Chrome (or Chromium) can be used for headless sessions.
 
-Connecting to an existing session
----------------------------------
+Connecting to an existing interactive session
+---------------------------------------------
 
 Use the ``interact`` method if you want to use scripting to control a CARTA session which you already have open in your browser.
 
@@ -58,10 +58,29 @@ To connect to a controller instance, you must authenticate to obtain a controlle
 
     session = Session.interact("FRONTEND URL", 123456, ControllerToken.from_file("path/to/token"))
 
-Creating a new session
-----------------------
+Creating a new interactive session
+----------------------------------
 
-Use the ``create`` method if you want to write a non-interactive script which starts a new session in a headless browser, performs a series of actions, and saves output, with no input from you.
+Use the ``start_and_interact`` method if you want to start the backend process from an interactive Python session and connect to the default CARTA session which is automatically opened in your browser on startup.
+
+This method parses the frontend URL and the session ID from the output of the backend process.
+
+The wrapper can start the backend process on your local computer, or on a remote host if your Unix user has the appropriate permissions to ssh to the remote host without entering a password. This method cannot be used with a controller.
+
+.. code-block:: python
+
+    from carta.session import Session
+
+    # New session, start local backend
+    session = Session.start_and_interact()
+
+    # New session, start remote backend
+    session = Session.start_and_interact(remote_host="REMOTE HOSTNAME OR IP")
+
+Creating a new non-interactive session
+--------------------------------------
+
+Use the ``create`` method if you want to write a non-interactive script which starts a new session in a headless browser, performs a series of actions, and saves output, with no input from you. The ``start_and_create`` method additionally starts a backend process first.
 
 The wrapper automatically parses the session ID from the frontend. If the wrapper also starts the backend process, it parses the frontend URL from the backend output. If you want to connect to an existing backend process, you must provide the frontend URL and the security token. You may omit the token if it is included in the URL.
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="carta",
-    version="1.1.5",
+    version="1.1.6",
     author="Adrianna Pińska",
     author_email="adrianna.pinska@gmail.com",
     description="CARTA scripting wrapper written in Python",


### PR DESCRIPTION
Implements #69. Note that this is new behaviour which is distinct from starting the backend and creating *headless* sessions -- it allows the user to start a new interactive CARTA session from inside a Jupyter notebook, Python interpreter, etc., instead of starting CARTA separately and copying the frontend URL and session ID into the `interact` method by hand. This is not intended for use from non-interactive scripts -- that doesn't really make sense because the backend process is killed when the Python session exits (if you do this by mistake you should be able to start CARTA again and reconnect from your orphaned browser session; this seemed to work when I tried it).

I have tested this on Ubuntu. It still needs to be tested with the Electron app.

This *should* work with the Electron executable as long as it
1. accepts the `--enable_scripting` flag
2. prints the full backend output to the terminal (including the frontend URL and session ID lines).
 
It should also work with the launcher script used to bypass Electron for the headless session, assuming that it meets the same requirements and also does not suppress the opening of a new session in the browser by default. (It should, however, accept the `--no_browser` flag, so that it can do this when it is used for headless sessions).

Usage:

```
from carta.session import Session
session = Session.start_and_interact()
```

By default this method assumes that the executable name / path is just `carta`; to specify a different executable path, use the `executable_path` parameter.