### PR TITLE
LabelType enum names and values must match frontend

### DIFF
--- a/carta/constants.py
+++ b/carta/constants.py
@@ -20,8 +20,8 @@ CoordinateSystem.__doc__ = """Coordinate systems."""
 
 class LabelType(str, Enum):
     """Label types."""
-    INTERNAL = "Internal"
-    EXTERNAL = "External"
+    INTERIOR = "Interior"
+    EXTERIOR = "Exterior"
 
 
 class BeamType(str, Enum):


### PR DESCRIPTION
Previously the incorrect values would have been accepted and set by the frontend (which would have led to unexpected behaviour later).