### PR TITLE
Icchen/75 single multiple panel

### DIFF
--- a/carta/constants.py
+++ b/carta/constants.py
@@ -139,3 +139,11 @@ class Polarization(IntEnum):
     PFTOTAL = 15
     PFLINEAR = 16
     PANGLE = 17
+
+PanelMode = Enum('PanelMode', ('SINGLE', 'MULTIPLE'), type=int, start=0)
+PanelMode.__doc__ = """Panel modes."""
+
+class GridMode(str, Enum):
+    """Grid modes."""
+    DYNAMIC = "dynamic"
+    FIXED = "fixed"

--- a/carta/constants.py
+++ b/carta/constants.py
@@ -140,8 +140,10 @@ class Polarization(IntEnum):
     PFLINEAR = 16
     PANGLE = 17
 
+
 PanelMode = Enum('PanelMode', ('SINGLE', 'MULTIPLE'), type=int, start=0)
 PanelMode.__doc__ = """Panel modes."""
+
 
 class GridMode(str, Enum):
     """Grid modes."""

--- a/carta/session.py
+++ b/carta/session.py
@@ -427,12 +427,15 @@ class Session:
         Parameters
         ----------
         panel : {0}
-            To use single-panel mode (``single``) or multiple-panel mode (``multiple``). Default is ``single``.
+            To adopt single-panel mode (``single``) or multiple-panel mode (``multiple``). Default is ``single``.
         """
         if panel is "single":
             if_multiple = False
         elif panel is "multiple":
             if_multiple = True
+        else:
+            logger.warning('Cannot proceed with the input panel argument. Please set "single" or "multiple" for the argument.')
+            return
         self.call_action("widgetsStore.setImageMultiPanelEnabled", if_multiple)
 
     def previous_page(self):
@@ -443,8 +446,8 @@ class Session:
         """Go to next page in viewer."""
         self.call_action("widgetsStore.onNextPageClick")
 
-    @validate(Number(), Number())
-    def set_viewer_grid(self, columns=2, rows=2):
+    @validate(OneOf(*range(1, 101)), OneOf(*range(1, 101)), String())
+    def set_viewer_grid(self, columns=2, rows=2, mode="dynamic"):
         """
         Set number of columns and rows in viewer grid.
 
@@ -454,10 +457,17 @@ class Session:
             Number of columns. Default is 2.
         rows : {1}
             Number of rows. Default is 2.
+        mode : {2}
+            To adopt dynamic grid size mode (``dynamic``) or fixed grid size mode(``fixed``). ``dynamic`` is set as default.
         """
         self.call_action("widgetsStore.setImageMultiPanelEnabled", True)
         self.call_action("preferenceStore.setPreference", "imagePanelColumns", columns)
         self.call_action("preferenceStore.setPreference", "imagePanelRows", rows)
+        if mode is "dynamic" or mode is "fixed":
+            self.call_action("preferenceStore.setPreference", "imagePanelMode", mode)
+        else:
+            logger.warning('Cannot proceed with the input mode argument. Please set "dynamic" or "fixed" for the argument')
+            return
 
     # CANVAS AND OVERLAY
     @validate(Number(), Number())

--- a/carta/session.py
+++ b/carta/session.py
@@ -417,6 +417,11 @@ class Session:
         """Clear the raster scaling reference."""
         self.call_action("clearRasterScalingReference")
 
+    # VIEWER MODES
+    @validate(Boolean())
+    def set_viewer_mode(self, if_multiple=True):
+        self.call_action("widgetsStore.setImageMultiPanelEnabled", if_multiple)
+
     # CANVAS AND OVERLAY
     @validate(Number(), Number())
     def set_view_area(self, width, height):

--- a/carta/session.py
+++ b/carta/session.py
@@ -420,13 +420,39 @@ class Session:
     # VIEWER MODES
     @validate(Boolean())
     def set_viewer_mode(self, if_multiple=True):
+        """
+        Switch between single-panel mode and multiple-panel mode.
+
+        Parameters
+        ----------
+        if_multiple : {0}
+            Argument to decide if multiple-mode is adopted. Default is True.
+        """
         self.call_action("widgetsStore.setImageMultiPanelEnabled", if_multiple)
 
     def previous_page(self):
+        """Go to previous page on viewer"""
         self.call_action("widgetsStore.onPreviousPageClick")
 
     def next_page(self):
+        """GO to next page on viewer"""
         self.call_action("widgetsStore.onNextPageClick")
+
+    @validate(Number(), Number())
+    def set_viewer_grid(self, n_column=2, n_row=2):
+        """
+        Set numbers of columns and rows for viewer grids.
+
+        Parameters
+        ----------
+        n_column : {0}
+            Number of columns; Default is 2.
+        n_row : {1}
+            Number of rows; Default is 2.
+        """
+        self.call_action("widgetsStore.setImageMultiPanelEnabled", True)
+        self.call_action("preferenceStore.setPreference", "imagePanelColumns", n_column)
+        self.call_action("preferenceStore.setPreference", "imagePanelRows", n_row)
 
     # CANVAS AND OVERLAY
     @validate(Number(), Number())

--- a/carta/session.py
+++ b/carta/session.py
@@ -9,7 +9,7 @@ Alternatively, the user can create a new session which runs in a headless browse
 import base64
 
 from .image import Image
-from .constants import CoordinateSystem, LabelType, BeamType, PaletteColor, Overlay
+from .constants import CoordinateSystem, LabelType, BeamType, PaletteColor, Overlay, PanelMode, GridMode
 from .backend import Backend
 from .protocol import Protocol
 from .util import logger, Macro, split_action_path, CartaBadID, CartaBadSession, CartaBadUrl
@@ -419,21 +419,21 @@ class Session:
         self.call_action("clearRasterScalingReference")
 
     # VIEWER MODES
-    @validate(OneOf(["single", "multiple"]))
-    def set_viewer_mode(self, mode):
+    @validate(Constant(PanelMode))
+    def set_viewer_mode(self, panel_mode):
         """
         Switch between single-panel mode and multiple-panel mode.
 
         Parameters
         ----------
-        panel : {0}
-            To adopt single-panel mode (``single``) or multiple-panel mode (``multiple``).
+        panel_mode : {0}
+            To adopt single-panel mode (``0``) or multiple-panel mode (``1``).
         """
-        if mode is "single":
-            if_multiple = False
-        elif mode is "multiple":
-            if_multiple = True
-        self.call_action("widgetsStore.setImageMultiPanelEnabled", if_multiple)
+        if panel_mode == PanelMode.SINGLE.value:
+            multiple = False
+        elif panel_mode == PanelMode.MULTIPLE.value:
+            multiple = True
+        self.call_action("widgetsStore.setImageMultiPanelEnabled", multiple)
 
     def previous_page(self):
         """Go to previous page in viewer."""
@@ -443,8 +443,8 @@ class Session:
         """Go to next page in viewer."""
         self.call_action("widgetsStore.onNextPageClick")
 
-    @validate(OneOf(*range(1, 11)), OneOf(*range(1, 11)), OneOf(["dynamic", "fixed"]))
-    def set_viewer_grid(self, rows, columns, mode="fixed"):
+    @validate(OneOf(*range(1, 11)), OneOf(*range(1, 11)), Constant(GridMode))
+    def set_viewer_grid(self, rows, columns, grid_mode=GridMode.FIXED.value):
         """
         Set number of columns and rows in viewer grid.
 
@@ -454,13 +454,13 @@ class Session:
             Number of rows.
         columns : {1}
             Number of columns.
-        mode : {2}
+        grid_mode : {2}
             To adopt dynamic grid size mode (``dynamic``) or fixed grid size mode(``fixed``). Default is ``fixed``.
         """
         self.call_action("widgetsStore.setImageMultiPanelEnabled", True)
         self.call_action("preferenceStore.setPreference", "imagePanelRows", rows)
         self.call_action("preferenceStore.setPreference", "imagePanelColumns", columns)
-        self.call_action("preferenceStore.setPreference", "imagePanelMode", mode)
+        self.call_action("preferenceStore.setPreference", "imagePanelMode", grid_mode)
 
     # CANVAS AND OVERLAY
     @validate(Number(), Number())

--- a/carta/session.py
+++ b/carta/session.py
@@ -426,7 +426,7 @@ class Session:
         Parameters
         ----------
         if_multiple : {0}
-            Argument to decide if multiple-mode is adopted. Default is True.
+            Whether to use multiple-panel mode. By default is ``True``.
         """
         self.call_action("widgetsStore.setImageMultiPanelEnabled", if_multiple)
 
@@ -435,24 +435,24 @@ class Session:
         self.call_action("widgetsStore.onPreviousPageClick")
 
     def next_page(self):
-        """GO to next page on viewer"""
+        """Go to next page on viewer"""
         self.call_action("widgetsStore.onNextPageClick")
 
     @validate(Number(), Number())
-    def set_viewer_grid(self, n_column=2, n_row=2):
+    def set_viewer_grid(self, n_columns=2, n_rows=2):
         """
         Set numbers of columns and rows for viewer grids.
 
         Parameters
         ----------
         n_column : {0}
-            Number of columns; Default is 2.
+            Number of columns. By default is 2.
         n_row : {1}
-            Number of rows; Default is 2.
+            Number of rows. By default is 2.
         """
         self.call_action("widgetsStore.setImageMultiPanelEnabled", True)
-        self.call_action("preferenceStore.setPreference", "imagePanelColumns", n_column)
-        self.call_action("preferenceStore.setPreference", "imagePanelRows", n_row)
+        self.call_action("preferenceStore.setPreference", "imagePanelColumns", n_columns)
+        self.call_action("preferenceStore.setPreference", "imagePanelRows", n_rows)
 
     # CANVAS AND OVERLAY
     @validate(Number(), Number())

--- a/carta/session.py
+++ b/carta/session.py
@@ -419,16 +419,16 @@ class Session:
 
     # VIEWER MODES
     @validate(Boolean())
-    def set_viewer_mode(self, if_multiple=True):
+    def set_viewer_mode(self, multiple=True):
         """
         Switch between single-panel mode and multiple-panel mode.
 
         Parameters
         ----------
-        if_multiple : {0}
+        multiple : {0}
             Whether to use multiple-panel mode. By default is ``True``.
         """
-        self.call_action("widgetsStore.setImageMultiPanelEnabled", if_multiple)
+        self.call_action("widgetsStore.setImageMultiPanelEnabled", multiple)
 
     def previous_page(self):
         """Go to previous page on viewer"""

--- a/carta/session.py
+++ b/carta/session.py
@@ -426,33 +426,33 @@ class Session:
         Parameters
         ----------
         multiple : {0}
-            Whether to use multiple-panel mode. By default is ``True``.
+            Whether to use multiple-panel mode. Default is ``True``.
         """
         self.call_action("widgetsStore.setImageMultiPanelEnabled", multiple)
 
     def previous_page(self):
-        """Go to previous page on viewer"""
+        """Go to previous page in viewer"""
         self.call_action("widgetsStore.onPreviousPageClick")
 
     def next_page(self):
-        """Go to next page on viewer"""
+        """Go to next page in viewer"""
         self.call_action("widgetsStore.onNextPageClick")
 
     @validate(Number(), Number())
-    def set_viewer_grid(self, n_columns=2, n_rows=2):
+    def set_viewer_grid(self, columns=2, rows=2):
         """
-        Set numbers of columns and rows for viewer grids.
+        Set number of columns and rows for viewer grid.
 
         Parameters
         ----------
-        n_column : {0}
-            Number of columns. By default is 2.
-        n_row : {1}
-            Number of rows. By default is 2.
+        columns : {0}
+            Number of columns. Default is 2.
+        rows : {1}
+            Number of rows. Default is 2.
         """
         self.call_action("widgetsStore.setImageMultiPanelEnabled", True)
-        self.call_action("preferenceStore.setPreference", "imagePanelColumns", n_columns)
-        self.call_action("preferenceStore.setPreference", "imagePanelRows", n_rows)
+        self.call_action("preferenceStore.setPreference", "imagePanelColumns", columns)
+        self.call_action("preferenceStore.setPreference", "imagePanelRows", rows)
 
     # CANVAS AND OVERLAY
     @validate(Number(), Number())

--- a/carta/session.py
+++ b/carta/session.py
@@ -427,11 +427,11 @@ class Session:
         Parameters
         ----------
         panel_mode : {0}
-            To adopt single-panel mode (``0``) or multiple-panel mode (``1``).
+            To adopt single-panel mode (:obj:`carta.constants.PanelMode.SINGLE`) or multiple-panel mode (:obj:`carta.constants.PanelMode.MULTIPLE`).
         """
-        if panel_mode == PanelMode.SINGLE.value:
+        if panel_mode == PanelMode.SINGLE:
             multiple = False
-        elif panel_mode == PanelMode.MULTIPLE.value:
+        elif panel_mode == PanelMode.MULTIPLE:
             multiple = True
         self.call_action("widgetsStore.setImageMultiPanelEnabled", multiple)
 
@@ -444,7 +444,7 @@ class Session:
         self.call_action("widgetsStore.onNextPageClick")
 
     @validate(OneOf(*range(1, 11)), OneOf(*range(1, 11)), Constant(GridMode))
-    def set_viewer_grid(self, rows, columns, grid_mode=GridMode.FIXED.value):
+    def set_viewer_grid(self, rows, columns, grid_mode=GridMode.FIXED):
         """
         Set number of columns and rows in viewer grid.
 
@@ -455,7 +455,7 @@ class Session:
         columns : {1}
             Number of columns.
         grid_mode : {2}
-            To adopt dynamic grid size mode (``dynamic``) or fixed grid size mode(``fixed``). Default is ``fixed``.
+            To adopt dynamic grid size mode (:obj:`grid_mode=GridMode.DYNAMIC`) or fixed grid size mode(:obj:`grid_mode=GridMode.FIXED`). Default is :obj:`grid_mode=GridMode.FIXED`.
         """
         self.call_action("widgetsStore.setImageMultiPanelEnabled", True)
         self.call_action("preferenceStore.setPreference", "imagePanelRows", rows)

--- a/carta/session.py
+++ b/carta/session.py
@@ -419,17 +419,21 @@ class Session:
         self.call_action("clearRasterScalingReference")
 
     # VIEWER MODES
-    @validate(Boolean())
-    def set_viewer_mode(self, multiple=True):
+    @validate(String())
+    def set_viewer_mode(self, panel="single"):
         """
         Switch between single-panel mode and multiple-panel mode.
 
         Parameters
         ----------
-        multiple : {0}
-            Whether to use multiple-panel mode. Default is ``True``.
+        panel : {0}
+            To use single-panel mode (``single``) or multiple-panel mode (``multiple``). Default is ``single``.
         """
-        self.call_action("widgetsStore.setImageMultiPanelEnabled", multiple)
+        if panel is "single":
+            if_multiple = False
+        elif panel is "multiple":
+            if_multiple = True
+        self.call_action("widgetsStore.setImageMultiPanelEnabled", if_multiple)
 
     def previous_page(self):
         """Go to previous page in viewer."""

--- a/carta/session.py
+++ b/carta/session.py
@@ -427,7 +427,7 @@ class Session:
         Parameters
         ----------
         panel_mode : {0}
-            To adopt single-panel mode (:obj:`carta.constants.PanelMode.SINGLE`) or multiple-panel mode (:obj:`carta.constants.PanelMode.MULTIPLE`).
+            The panel mode to adopt.
         """
         if panel_mode == PanelMode.SINGLE:
             multiple = False
@@ -455,7 +455,7 @@ class Session:
         columns : {1}
             Number of columns.
         grid_mode : {2}
-            To adopt dynamic grid size mode (:obj:`grid_mode=GridMode.DYNAMIC`) or fixed grid size mode(:obj:`grid_mode=GridMode.FIXED`). Default is :obj:`grid_mode=GridMode.FIXED`.
+            The grid mode to adopt. The default is :obj:`carta.constants.GridMode.FIXED`.
         """
         self.call_action("widgetsStore.setImageMultiPanelEnabled", True)
         self.call_action("preferenceStore.setPreference", "imagePanelRows", rows)

--- a/carta/session.py
+++ b/carta/session.py
@@ -419,23 +419,20 @@ class Session:
         self.call_action("clearRasterScalingReference")
 
     # VIEWER MODES
-    @validate(String())
-    def set_viewer_mode(self, panel="single"):
+    @validate(OneOf(["single", "multiple"]))
+    def set_viewer_mode(self, mode):
         """
         Switch between single-panel mode and multiple-panel mode.
 
         Parameters
         ----------
         panel : {0}
-            To adopt single-panel mode (``single``) or multiple-panel mode (``multiple``). Default is ``single``.
+            To adopt single-panel mode (``single``) or multiple-panel mode (``multiple``).
         """
-        if panel is "single":
+        if mode is "single":
             if_multiple = False
-        elif panel is "multiple":
+        elif mode is "multiple":
             if_multiple = True
-        else:
-            logger.warning('Cannot proceed with the input panel argument. Please set "single" or "multiple" for the argument.')
-            return
         self.call_action("widgetsStore.setImageMultiPanelEnabled", if_multiple)
 
     def previous_page(self):
@@ -446,28 +443,24 @@ class Session:
         """Go to next page in viewer."""
         self.call_action("widgetsStore.onNextPageClick")
 
-    @validate(OneOf(*range(1, 101)), OneOf(*range(1, 101)), String())
-    def set_viewer_grid(self, columns=2, rows=2, mode="dynamic"):
+    @validate(OneOf(*range(1, 11)), OneOf(*range(1, 11)), OneOf(["dynamic", "fixed"]))
+    def set_viewer_grid(self, rows, columns, mode="fixed"):
         """
         Set number of columns and rows in viewer grid.
 
         Parameters
         ----------
-        columns : {0}
-            Number of columns. Default is 2.
-        rows : {1}
-            Number of rows. Default is 2.
+        rows : {0}
+            Number of rows.
+        columns : {1}
+            Number of columns.
         mode : {2}
-            To adopt dynamic grid size mode (``dynamic``) or fixed grid size mode(``fixed``). ``dynamic`` is set as default.
+            To adopt dynamic grid size mode (``dynamic``) or fixed grid size mode(``fixed``). Default is ``fixed``.
         """
         self.call_action("widgetsStore.setImageMultiPanelEnabled", True)
-        self.call_action("preferenceStore.setPreference", "imagePanelColumns", columns)
         self.call_action("preferenceStore.setPreference", "imagePanelRows", rows)
-        if mode is "dynamic" or mode is "fixed":
-            self.call_action("preferenceStore.setPreference", "imagePanelMode", mode)
-        else:
-            logger.warning('Cannot proceed with the input mode argument. Please set "dynamic" or "fixed" for the argument')
-            return
+        self.call_action("preferenceStore.setPreference", "imagePanelColumns", columns)
+        self.call_action("preferenceStore.setPreference", "imagePanelMode", mode)
 
     # CANVAS AND OVERLAY
     @validate(Number(), Number())

--- a/carta/session.py
+++ b/carta/session.py
@@ -422,6 +422,12 @@ class Session:
     def set_viewer_mode(self, if_multiple=True):
         self.call_action("widgetsStore.setImageMultiPanelEnabled", if_multiple)
 
+    def previous_page(self):
+        self.call_action("widgetsStore.onPreviousPageClick")
+
+    def next_page(self):
+        self.call_action("widgetsStore.onNextPageClick")
+
     # CANVAS AND OVERLAY
     @validate(Number(), Number())
     def set_view_area(self, width, height):

--- a/carta/session.py
+++ b/carta/session.py
@@ -431,17 +431,17 @@ class Session:
         self.call_action("widgetsStore.setImageMultiPanelEnabled", multiple)
 
     def previous_page(self):
-        """Go to previous page in viewer"""
+        """Go to previous page in viewer."""
         self.call_action("widgetsStore.onPreviousPageClick")
 
     def next_page(self):
-        """Go to next page in viewer"""
+        """Go to next page in viewer."""
         self.call_action("widgetsStore.onNextPageClick")
 
     @validate(Number(), Number())
     def set_viewer_grid(self, columns=2, rows=2):
         """
-        Set number of columns and rows for viewer grid.
+        Set number of columns and rows in viewer grid.
 
         Parameters
         ----------


### PR DESCRIPTION
This PR is to resolve #75.

Four functions: `set_viewer_mode`, `previous_page`, `next_page` and `set_viewer_grid` are added to `session.py`.
`set_viewer_mode`: Switch between single-mode and multiple-mode.
`previous_page`: Click "previous page" button
`previous_page`: Click "next page" button
`set_viewer_grid`: Set "Enable multi-panel" to `True` and define the number of columns and/or rows.