### PR TITLE
Icchen/77 clip level for colormap mapping

### DIFF
--- a/carta/image.py
+++ b/carta/image.py
@@ -484,7 +484,7 @@ class Image:
             self.call_action("renderConfig.resetContrast")
 
     # TODO check whether this works as expected
-    @validate(Constant(Scaling), NoneOr(Number()), NoneOr(Number()), NoneOr(Number()), NoneOr(Number()), NoneOr(Number()))
+    @validate(Constant(Scaling), NoneOr(Number()), NoneOr(Number()), NoneOr(Number(0, 100)), NoneOr(Number()), NoneOr(Number()))
     def set_scaling(self, scaling, alpha=None, gamma=None, rank=None, min=None, max=None):
         """Set the colormap scaling.
 
@@ -702,7 +702,13 @@ class Image:
         rank : {0}
             The percentile rank.
         """
+        percentile_ranks = [90, 95, 99, 99.5, 99.9, 99.95, 99.99, 100]
         self.call_action("renderConfig.setPercentileRank", rank)
+        min_val = self.get_value("renderConfig.scaleMinVal")
+        max_val = self.get_value("renderConfig.scaleMaxVal")
+        if rank not in percentile_ranks:
+            self.call_action("renderConfig.setCustomScale", min_val, max_val)
+
 
     # CLOSE
 

--- a/carta/image.py
+++ b/carta/image.py
@@ -466,7 +466,7 @@ class Image:
 
     # TODO check whether this works as expected
     @validate(Constant(Scaling), NoneOr(Number()), NoneOr(Number()), NoneOr(Number()), NoneOr(Number()), NoneOr(Number()))
-    def set_scaling(self, scaling, alpha=None, gamma=None, clip=None, min=None, max=None):
+    def set_scaling(self, scaling, alpha=None, gamma=None, rank=None, min=None, max=None):
         """Set the colormap scaling.
 
         Parameters
@@ -477,24 +477,21 @@ class Image:
             The alpha value (only applicable to ``LOG`` and ``POWER`` scaling types).
         gamma : {2}
             The gamma value (only applicable to the ``GAMMA`` scaling type).
-        clip : {3}
-            The scale clip. In percentage. Can not be used witn *min* and *max*.
+        rank : {3}
+            The percentile rank. If this is set, *min* and *max* are ignored, and will be calculated automatically.
         min : {4}
-            The minimum of the scale. Only used if both *min* and *max* are set. Can not be used with *clip*.
+            Custom clip minimum. Only used if both *min* and *max* are set. Ignored if *rank* is set.
         max : {5}
-            The maximum of the scale. Only used if both *min* and *max* are set. Can not be used with *clip*.
+            Custom clip maximum. Only used if both *min* and *max* are set. Ignored if *rank* is set.
         """
         self.call_action("renderConfig.setScaling", scaling)
         if scaling in (Scaling.LOG, Scaling.POWER) and alpha is not None:
             self.call_action("renderConfig.setAlpha", alpha)
         elif scaling == Scaling.GAMMA and gamma is not None:
             self.call_action("renderConfig.setGamma", gamma)
-        if clip is not None:
-            min = "None"
-            max = "None"
-            self.call_action("renderConfig.setPercentileRank", clip)
+        if rank is not None:
+            self.set_percentile_rank(rank)
         elif min is not None and max is not None:
-            clip = "None"
             self.call_action("renderConfig.setCustomScale", min, max)
 
     @validate(Boolean())

--- a/carta/image.py
+++ b/carta/image.py
@@ -465,8 +465,8 @@ class Image:
             self.call_action("renderConfig.resetContrast")
 
     # TODO check whether this works as expected
-    @validate(Constant(Scaling), NoneOr(Number()), NoneOr(Number()), NoneOr(Number()), NoneOr(Number()))
-    def set_scaling(self, scaling, alpha=None, gamma=None, min=None, max=None):
+    @validate(Constant(Scaling), NoneOr(Number()), NoneOr(Number()), NoneOr(Number()), NoneOr(Number()), NoneOr(Number()))
+    def set_scaling(self, scaling, alpha=None, gamma=None, clip=None, min=None, max=None):
         """Set the colormap scaling.
 
         Parameters
@@ -477,18 +477,27 @@ class Image:
             The alpha value (only applicable to ``LOG`` and ``POWER`` scaling types).
         gamma : {2}
             The gamma value (only applicable to the ``GAMMA`` scaling type).
-        min : {3}
-            The minimum of the scale. Only used if both *min* and *max* are set.
-        max : {4}
-            The maximum of the scale. Only used if both *min* and *max* are set.
+        clip : {3}
+            The scale clip. In percentage. Can not be used witn *min* and *max*.
+        min : {4}
+            The minimum of the scale. Only used if both *min* and *max* are set. Can not be used with *clip*.
+        max : {5}
+            The maximum of the scale. Only used if both *min* and *max* are set. Can not be used with *clip*.
         """
         self.call_action("renderConfig.setScaling", scaling)
         if scaling in (Scaling.LOG, Scaling.POWER) and alpha is not None:
             self.call_action("renderConfig.setAlpha", alpha)
         elif scaling == Scaling.GAMMA and gamma is not None:
             self.call_action("renderConfig.setGamma", gamma)
-        if min is not None and max is not None:
+        if clip is not None:
+            min = "None"
+            max = "None"
+            self.call_action("renderConfig.setPercentileRank", clip)
+        elif min is not None and max is not None:
+            clip = "None"
             self.call_action("renderConfig.setCustomScale", min, max)
+        # elif (clip is not None) and (min is not None or max is not None):
+        #     self.logger.warning(...)
 
     @validate(Boolean())
     def set_raster_visible(self, state):

--- a/carta/image.py
+++ b/carta/image.py
@@ -704,11 +704,8 @@ class Image:
         """
         percentile_ranks = [90, 95, 99, 99.5, 99.9, 99.95, 99.99, 100]
         self.call_action("renderConfig.setPercentileRank", rank)
-        min_val = self.get_value("renderConfig.scaleMinVal")
-        max_val = self.get_value("renderConfig.scaleMaxVal")
         if rank not in percentile_ranks:
-            self.call_action("renderConfig.setCustomScale", min_val, max_val)
-
+            self.call_action("renderConfig.setPercentileRank", -1)
 
     # CLOSE
 

--- a/carta/image.py
+++ b/carta/image.py
@@ -702,10 +702,10 @@ class Image:
         rank : {0}
             The percentile rank.
         """
-        percentile_ranks = [90, 95, 99, 99.5, 99.9, 99.95, 99.99, 100]
+        preset_ranks = [90, 95, 99, 99.5, 99.9, 99.95, 99.99, 100]
         self.call_action("renderConfig.setPercentileRank", rank)
-        if rank not in percentile_ranks:
-            self.call_action("renderConfig.setPercentileRank", -1)
+        if rank not in preset_ranks:
+            self.call_action("renderConfig.setPercentileRank", -1) # select 'custom' rank button
 
     # CLOSE
 

--- a/carta/image.py
+++ b/carta/image.py
@@ -478,7 +478,7 @@ class Image:
         gamma : {2}
             The gamma value (only applicable to the ``GAMMA`` scaling type).
         rank : {3}
-            The percentile rank. If this is set, *min* and *max* are ignored, and will be calculated automatically.
+            The clip percentile rank. If this is set, *min* and *max* are ignored, and will be calculated automatically.
         min : {4}
             Custom clip minimum. Only used if both *min* and *max* are set. Ignored if *rank* is set.
         max : {5}
@@ -490,7 +490,7 @@ class Image:
         elif scaling == Scaling.GAMMA and gamma is not None:
             self.call_action("renderConfig.setGamma", gamma)
         if rank is not None:
-            self.set_percentile_rank(rank)
+            self.set_clip_percentile(rank)
         elif min is not None and max is not None:
             self.call_action("renderConfig.setCustomScale", min, max)
 
@@ -634,8 +634,8 @@ class Image:
         self.call_action(f"renderConfig.setUseCubeHistogram{'Contours' if contours else ''}", False)
 
     @validate(Number(0, 100))
-    def set_percentile_rank(self, rank):
-        """Set the percentile rank.
+    def set_clip_percentile(self, rank):
+        """Set the clip percentile.
 
         Parameters
         ----------

--- a/carta/image.py
+++ b/carta/image.py
@@ -5,7 +5,7 @@ Image objects should not be instantiated directly, and should only be created th
 import posixpath
 
 from .constants import Colormap, Scaling, SmoothingMode, ContourDashMode, Polarization
-from .util import Macro, cached
+from .util import logger, Macro, cached
 from .validation import validate, Number, Color, Constant, Boolean, NoneOr, IterableOf, Evaluate, Attr, Attrs, OneOf
 
 
@@ -496,8 +496,6 @@ class Image:
         elif min is not None and max is not None:
             clip = "None"
             self.call_action("renderConfig.setCustomScale", min, max)
-        # elif (clip is not None) and (min is not None or max is not None):
-        #     self.logger.warning(...)
 
     @validate(Boolean())
     def set_raster_visible(self, state):


### PR DESCRIPTION
This PR is to resolve #77.

An argument `rank` is added to the `set_scaling` function of `image.py`. `rank` (in %) is a used to call `renderConfig.setPercentileRank` at the frontend and calculate/set the `Clip min` and `Clip max` accordingly.

`clip` cannot be used with `min` and `max`, and vise versa. Since we're still having "`None` can not be serialized" problem, the "non-empty string" method is adopted initiatively to replace the `None` value.