### PR TITLE
Don't close session on action error; update some docstrings

### DIFF
--- a/carta/backend.py
+++ b/carta/backend.py
@@ -19,7 +19,7 @@ class Backend:
     Parameters
     ----------
     params : iterable
-        Parameters to pass to the CARTA backend process.
+        Parameters to pass to the CARTA backend process. Example: ["--verbosity", 5, "--port", 3010]
     executable_path : string
         The path to the backend executable. Default: ``"carta"``.
     remote_host : string

--- a/carta/backend.py
+++ b/carta/backend.py
@@ -19,7 +19,7 @@ class Backend:
     Parameters
     ----------
     params : iterable
-        Parameters to pass to the CARTA backend process. Example: ["--verbosity", 5, "--port", 3010]
+        Parameters to pass to the CARTA backend process. Example: ``["--verbosity", 5, "--port", 3010]``
     executable_path : string
         The path to the backend executable. Default: ``"carta"``.
     remote_host : string

--- a/carta/browser.py
+++ b/carta/browser.py
@@ -110,7 +110,7 @@ class Browser:
         remote_host : string, optional
             A remote host where the backend process should be launched, which must be accessible through passwordless ssh. By default the backend process is launched on the local host.
         params : iterable, optional
-            Additional parameters to be passed to the backend process. By default scripting is enabled and the automatic browser is disabled. The parameters are appended to the end of the command, so a positional parameter for a data directory can be included. Example: ["--verbosity", 5, "--port", 3010]
+            Additional parameters to be passed to the backend process. By default scripting is enabled and the automatic browser is disabled. The parameters are appended to the end of the command, so a positional parameter for a data directory can be included. Example: ``["--verbosity", 5, "--port", 3010]``
         timeout : number, optional
             The number of seconds to spend parsing the frontend for connection information. 10 seconds by default.
         token : :obj:`carta.token.BackendToken`, optional

--- a/carta/browser.py
+++ b/carta/browser.py
@@ -110,7 +110,7 @@ class Browser:
         remote_host : string, optional
             A remote host where the backend process should be launched, which must be accessible through passwordless ssh. By default the backend process is launched on the local host.
         params : iterable, optional
-            Additional parameters to be passed to the backend process. By default scripting is enabled and the automatic browser is disabled. The parameters are appended to the end of the command, so a positional parameter for a data directory can be included.
+            Additional parameters to be passed to the backend process. By default scripting is enabled and the automatic browser is disabled. The parameters are appended to the end of the command, so a positional parameter for a data directory can be included. Example: ["--verbosity", 5, "--port", 3010]
         timeout : number, optional
             The number of seconds to spend parsing the frontend for connection information. 10 seconds by default.
         token : :obj:`carta.token.BackendToken`, optional

--- a/carta/session.py
+++ b/carta/session.py
@@ -110,7 +110,7 @@ class Session:
         remote_host : string, optional
             A remote host where the backend process should be launched, which must be accessible through passwordless ssh. By default the backend process is launched on the local host.
         params : iterable, optional
-            Additional parameters to be passed to the backend process. By default scripting is enabled. The parameters are appended to the end of the command, so a positional parameter for a data directory can be included. Example: ["--verbosity", 5, "--port", 3010]
+            Additional parameters to be passed to the backend process. By default scripting is enabled. The parameters are appended to the end of the command, so a positional parameter for a data directory can be included. Example: ``["--verbosity", 5, "--port", 3010]``
         token : :obj:`carta.token.Token`, optional
             The security token to use. Parsed from the backend output by default.
         frontend_url_timeout : integer
@@ -194,7 +194,7 @@ class Session:
         remote_host : string, optional
             A remote host where the backend process should be launched, which must be accessible through passwordless ssh. By default the backend process is launched on the local host.
         params : iterable, optional
-            Additional parameters to be passed to the backend process. By default scripting is enabled and the automatic browser is disabled. The parameters are appended to the end of the command, so a positional parameter for a data directory can be included. Example: ["--verbosity", 5, "--port", 3010]
+            Additional parameters to be passed to the backend process. By default scripting is enabled and the automatic browser is disabled. The parameters are appended to the end of the command, so a positional parameter for a data directory can be included. Example: ``["--verbosity", 5, "--port", 3010]``
         timeout : integer, optional
             The number of seconds to spend parsing the frontend for connection information. 10 seconds by default.
         token : :obj:`carta.token.Token`, optional

--- a/carta/session.py
+++ b/carta/session.py
@@ -246,11 +246,7 @@ class Session:
         CartaBadResponse
             If a request which was expected to have a JSON response did not have one, or if a JSON response could not be decoded.
         """
-        try:
-            return self._protocol.request_scripting_action(self.session_id, path, *args, **kwargs)
-        except CartaScriptingException:
-            self.close()
-            raise
+        return self._protocol.request_scripting_action(self.session_id, path, *args, **kwargs)
 
     def get_value(self, path):
         """Get the value of an attribute from a frontend store.

--- a/carta/session.py
+++ b/carta/session.py
@@ -21,7 +21,12 @@ class Session:
 
     This class provides the core generic method for calling actions on the frontend (through the backend), as well as convenience methods which wrap this generic method and provide a more intuitive and user-friendly interface to frontend functionality associated with the session as a whole.
 
-    This class should not be instantiated directly. Three class methods are provided for creating different types of sessions with all the appropriate parameters set: :obj:`carta.session.Session.interact` for interacting with an existing CARTA session open in the user's browser, :obj:`carta.session.Session.create` for creating a new CARTA session in a headless browser by connecting to an existing CARTA backend or controller instance, and :obj:`carta.session.Session.start_and_create` for starting a new backend instance and then connecting to it to create a new session in a headless browser.
+    This class should not be instantiated directly. Four class methods are provided for creating different types of sessions with all the appropriate parameters set:
+
+    * :obj:`carta.session.Session.interact` for interacting with an existing CARTA session open in the user's browser.
+    * :obj:`carta.session.Session.start_and_interact` for starting a new backend instance and then interacting with the default session which is automatically opened by the backend in the user's browser.
+    * :obj:`carta.session.Session.create` for creating a new CARTA session in a headless browser by connecting to an existing CARTA backend or controller instance.
+    * :obj:`carta.session.Session.start_and_create` for starting a new backend instance and then connecting to it to create a new session in a headless browser.
 
     The session object can be used to create image objects, which provide analogous convenience methods for functionality associated with individual images.
 
@@ -797,11 +802,11 @@ class Session:
             f.write(self.rendered_view_data(background_color))
 
     def close(self):
-        """Close the browser session and stop the backend process, if applicable.
+        """Close any browser sessions and backend processes controlled by this session object.
 
-        If this session was newly created in a headless browser, close the browser session. If a new backend process was also started, stop the backend process.
+        If this session opened a CARTA frontend session in a headless browser, this method will close the browser together with that session. If this session is interacting with a session running in an external browser, that browser session will be unaffected. This includes the new CARTA frontend session which is started automatically when :obj:`carta.session.Session.start_and_interact` is used: that frontend session is opened in the user's browser, which is not controlled by this object.
 
-        If this session is interacting with an existing external browser session, this method has no effect.
+        If this session started a new backend process, this method will stop that process. If this session is interacting with an externally started backend process, that process will be unaffected.
         """
 
         if self._browser is not None:

--- a/carta/session.py
+++ b/carta/session.py
@@ -110,7 +110,7 @@ class Session:
         remote_host : string, optional
             A remote host where the backend process should be launched, which must be accessible through passwordless ssh. By default the backend process is launched on the local host.
         params : iterable, optional
-            Additional parameters to be passed to the backend process. By default scripting is enabled. The parameters are appended to the end of the command, so a positional parameter for a data directory can be included.
+            Additional parameters to be passed to the backend process. By default scripting is enabled. The parameters are appended to the end of the command, so a positional parameter for a data directory can be included. Example: ["--verbosity", 5, "--port", 3010]
         token : :obj:`carta.token.Token`, optional
             The security token to use. Parsed from the backend output by default.
         frontend_url_timeout : integer
@@ -194,7 +194,7 @@ class Session:
         remote_host : string, optional
             A remote host where the backend process should be launched, which must be accessible through passwordless ssh. By default the backend process is launched on the local host.
         params : iterable, optional
-            Additional parameters to be passed to the backend process. By default scripting is enabled and the automatic browser is disabled. The parameters are appended to the end of the command, so a positional parameter for a data directory can be included.
+            Additional parameters to be passed to the backend process. By default scripting is enabled and the automatic browser is disabled. The parameters are appended to the end of the command, so a positional parameter for a data directory can be included. Example: ["--verbosity", 5, "--port", 3010]
         timeout : integer, optional
             The number of seconds to spend parsing the frontend for connection information. 10 seconds by default.
         token : :obj:`carta.token.Token`, optional


### PR DESCRIPTION
This fixes #94. There is no need to close the session when an action call results in an error. I don't believe that we need to take any action in response; this is something for the user to resolve and doesn't indicate any problem with the session.

I also updated some outdated docstrings, including a fix for #87.