### PR TITLE
Confluence/union noneor interface fix

### DIFF
--- a/carta/session.py
+++ b/carta/session.py
@@ -12,7 +12,7 @@ from .image import Image
 from .constants import CoordinateSystem, LabelType, BeamType, PaletteColor, Overlay
 from .backend import Backend
 from .protocol import Protocol
-from .util import logger, Macro, split_action_path, CartaScriptingException, CartaBadID, CartaBadSession, CartaBadUrl
+from .util import logger, Macro, split_action_path, CartaBadID, CartaBadSession, CartaBadUrl
 from .validation import validate, String, Number, Color, Constant, Boolean, NoneOr, OneOf
 
 

--- a/carta/validation.py
+++ b/carta/validation.py
@@ -273,8 +273,8 @@ class Union(Parameter):
 
     Parameters
     ----------
-    options : iterable of :obj:`carta.validation.Parameter` objects
-        An iterable of valid descriptors for this parameter
+    *options : iterable of :obj:`carta.validation.Parameter` objects
+        An iterable of valid descriptors for this parameter.
     description : str, optional
         A custom description. The default is generated from the descriptions of the provided options.
 
@@ -284,7 +284,7 @@ class Union(Parameter):
         An iterable of valid descriptors for this parameter.
     """
 
-    def __init__(self, options, description=None):
+    def __init__(self, *options, description=None):
         self.options = options
         self._description = description
 
@@ -368,25 +368,29 @@ class Constant(OneOf):
 
 
 class NoneOr(Union):
-    """A parameter which can match the given descriptor or ``None``. Used for optional parameters which are ``None`` by default.
+    """A union of other parameter descriptors as well as ``None``.
+
+    In the most common use case, this is used with a single other parameter type for optional parameters which are ``None`` by default. In more complex cases this can be used as shorthand in place of a :obj:`carta.validation.Union` with an explicit :obj:`carta.validation.NoneParameter` option.
 
     Parameters
     ----------
-    param : :obj:`carta.validation.Parameter`
-        The parameter descriptor.
+    *options : iterable of :obj:`carta.validation.Parameter` objects
+        An iterable of valid descriptors for this parameter, in addition to ``None``.
+    description : str, optional
+        A custom description. The default is generated from the descriptions of the provided options.
 
     Attributes
     ----------
-    param : :obj:`carta.validation.Parameter`
-        The parameter descriptor.
+    options : iterable of :obj:`carta.validation.Parameter` objects
+        An iterable of valid descriptors for this parameter, in addition to ``None``.
     """
 
-    def __init__(self, param):
+    def __init__(self, *options, description=None):
         options = (
-            param,
+            *options,
             NoneParameter(),
         )
-        super().__init__(options)
+        super().__init__(*options, description)
 
 
 class IterableOf(Parameter):

--- a/carta/validation.py
+++ b/carta/validation.py
@@ -390,7 +390,7 @@ class NoneOr(Union):
             *options,
             NoneParameter(),
         )
-        super().__init__(*options, description)
+        super().__init__(*options, description=description)
 
 
 class IterableOf(Parameter):
@@ -516,7 +516,7 @@ class Color(Union):
             String("#[0-9a-f]{3}", re.IGNORECASE),  # 3-digit hex
             TupleColor(),  # RGB, RGBA, HSL, HSLA
         )
-        super().__init__(options, "an HTML color specification")
+        super().__init__(*options, description="an HTML color specification")
 
 
 class Attr(str):


### PR DESCRIPTION
This is an internal interface update of the `Union` validation class and the classes which inherit from it. The old interface was out of sync with the `OneOf` class, which accepts options as unpacked `*args` -- `Union` required a single `options` parameter, which was less convenient. This PR also extends the behaviour of the `NoneOr` class, which inherits from `Union` -- it is now possible to use `NoneOr(list, of, options, here)` instead of having to nest an explicit `Union`, as in `NoneOr(Union(list, of, options, here))`.