### PR TITLE
Icchen/89 load complex image

### DIFF
--- a/carta/constants.py
+++ b/carta/constants.py
@@ -5,6 +5,12 @@ from enum import Enum, IntEnum
 
 # TODO make sure the __str__ is right for all the string values
 
+class ComplexValue(str, Enum):
+    """Complex values."""
+    AMPLITUDE = "AMPLITUDE"
+    PHASE = "PHASE"
+    REAL = "REAL"
+    IMAGINARY = "IMAGINARY"
 
 Colormap = Enum('Colormap', {c.upper(): c for c in ('copper', 'paired', 'gist_heat', 'brg', 'cool', 'summer', 'OrRd', 'tab20c', 'purples', 'gray', 'terrain', 'RdPu', 'set2', 'spring', 'gist_yarg', 'RdYlBu', 'reds', 'winter', 'Wistia', 'rainbow', 'dark2', 'oranges', 'BuPu', 'gist_earth', 'PuBu', 'pink', 'PuOr', 'pastel2', 'PiYG', 'gist_ncar', 'PuRd', 'plasma', 'gist_stern', 'hot', 'PuBuGn', 'YlOrRd', 'accent', 'magma', 'set1', 'GnBu', 'greens', 'CMRmap', 'gist_rainbow', 'prism', 'hsv', 'Blues', 'viridis', 'YlGn', 'spectral', 'RdBu', 'tab20', 'greys', 'flag', 'jet', 'seismic', 'PRGn', 'coolwarm', 'YlOrBr', 'RdYlGn', 'bone', 'autumn', 'BrBG', 'gnuplot2', 'RdGy', 'binary', 'gnuplot', 'BuGn', 'gist_gray', 'nipy_spectral', 'set3', 'tab20b', 'pastel1', 'afmhot', 'cubehelix', 'YlGnBu', 'ocean', 'tab10', 'bwr', 'inferno')}, type=str)
 Colormap.__doc__ = """All available colormaps."""

--- a/carta/constants.py
+++ b/carta/constants.py
@@ -5,12 +5,12 @@ from enum import Enum, IntEnum
 
 # TODO make sure the __str__ is right for all the string values
 
-class ComplexValue(str, Enum):
-    """Complex values."""
+class ArithmeticExpression(str, Enum):
+    """Arithmetic expression."""
     AMPLITUDE = "AMPLITUDE"
     PHASE = "PHASE"
     REAL = "REAL"
-    IMAGINARY = "IMAGINARY"
+    IMAG = "IMAG"
 
 Colormap = Enum('Colormap', {c.upper(): c for c in ('copper', 'paired', 'gist_heat', 'brg', 'cool', 'summer', 'OrRd', 'tab20c', 'purples', 'gray', 'terrain', 'RdPu', 'set2', 'spring', 'gist_yarg', 'RdYlBu', 'reds', 'winter', 'Wistia', 'rainbow', 'dark2', 'oranges', 'BuPu', 'gist_earth', 'PuBu', 'pink', 'PuOr', 'pastel2', 'PiYG', 'gist_ncar', 'PuRd', 'plasma', 'gist_stern', 'hot', 'PuBuGn', 'YlOrRd', 'accent', 'magma', 'set1', 'GnBu', 'greens', 'CMRmap', 'gist_rainbow', 'prism', 'hsv', 'Blues', 'viridis', 'YlGn', 'spectral', 'RdBu', 'tab20', 'greys', 'flag', 'jet', 'seismic', 'PRGn', 'coolwarm', 'YlOrBr', 'RdYlGn', 'bone', 'autumn', 'BrBG', 'gnuplot2', 'RdGy', 'binary', 'gnuplot', 'BuGn', 'gist_gray', 'nipy_spectral', 'set3', 'tab20b', 'pastel1', 'afmhot', 'cubehelix', 'YlGnBu', 'ocean', 'tab10', 'bwr', 'inferno')}, type=str)
 Colormap.__doc__ = """All available colormaps."""

--- a/carta/constants.py
+++ b/carta/constants.py
@@ -12,6 +12,7 @@ class ArithmeticExpression(str, Enum):
     REAL = "REAL"
     IMAG = "IMAG"
 
+
 Colormap = Enum('Colormap', {c.upper(): c for c in ('copper', 'paired', 'gist_heat', 'brg', 'cool', 'summer', 'OrRd', 'tab20c', 'purples', 'gray', 'terrain', 'RdPu', 'set2', 'spring', 'gist_yarg', 'RdYlBu', 'reds', 'winter', 'Wistia', 'rainbow', 'dark2', 'oranges', 'BuPu', 'gist_earth', 'PuBu', 'pink', 'PuOr', 'pastel2', 'PiYG', 'gist_ncar', 'PuRd', 'plasma', 'gist_stern', 'hot', 'PuBuGn', 'YlOrRd', 'accent', 'magma', 'set1', 'GnBu', 'greens', 'CMRmap', 'gist_rainbow', 'prism', 'hsv', 'Blues', 'viridis', 'YlGn', 'spectral', 'RdBu', 'tab20', 'greys', 'flag', 'jet', 'seismic', 'PRGn', 'coolwarm', 'YlOrBr', 'RdYlGn', 'bone', 'autumn', 'BrBG', 'gnuplot2', 'RdGy', 'binary', 'gnuplot', 'BuGn', 'gist_gray', 'nipy_spectral', 'set3', 'tab20b', 'pastel1', 'afmhot', 'cubehelix', 'YlGnBu', 'ocean', 'tab10', 'bwr', 'inferno')}, type=str)
 Colormap.__doc__ = """All available colormaps."""
 

--- a/carta/image.py
+++ b/carta/image.py
@@ -56,9 +56,9 @@ class Image:
         hdu : string
             The HDU to open.
         append : boolean
-            Whether the image should be appended. By default it is not, and all other open images are closed.
+            Whether the image should be appended.
         complex : a member of :obj:`carta.constants.ArithmeticExpression` or ``None``
-            Arithmetic expression to use if opening a complex-valued image. By default the image is assumed not to be complex.
+            Arithmetic expression to use if opening a complex-valued image. Set to ``None`` if the image is not complex, or to show the default amplitude if the image is complex.
 
         Returns
         -------

--- a/carta/image.py
+++ b/carta/image.py
@@ -42,7 +42,7 @@ class Image:
         self._frame = Macro("", self._base_path)
 
     @classmethod
-    def new(cls, session, path, hdu, append, complex=False, Expression=None):
+    def new(cls, session, path, hdu, append, complex, expression):
         """Open or append a new image in the session and return an image object associated with it.
 
         This method should not be used directly. It is wrapped by :obj:`carta.session.Session.open_image` and :obj:`carta.session.Session.append_image`.
@@ -58,9 +58,9 @@ class Image:
         append : boolean
             Whether the image should be appended.
         complex : boolean
-            Whether the image is complex. Set to ``False`` by default.
-        expression : a member of :obj:`carta.constants.ArithmeticExpression` or ``None``
-            Arithmetic expression to use if opening a complex-valued image. Set to ``None`` if the image is not complex, or to show the default amplitude if the image is complex.
+            Whether the image is complex.
+        expression : a member of :obj:`carta.constants.ArithmeticExpression`
+            Arithmetic expression to use if opening a complex-valued image.
 
         Returns
         -------
@@ -74,9 +74,7 @@ class Image:
             image_arithmetic = False
         elif complex is True:
             image_arithmetic = "true"
-            if Expression is None:
-                Expression = "AMPLITUDE"
-            file_name = f'{Expression}("{file_name}")'
+            file_name = f'{expression}("{file_name}")'
         image_id = session.call_action(command, directory, file_name, hdu, image_arithmetic, return_path="frameInfo.fileId")
         return cls(session, image_id, file_name)
 

--- a/carta/image.py
+++ b/carta/image.py
@@ -58,7 +58,7 @@ class Image:
         append : boolean
             Whether the image should be appended.
         complex : boolean
-            Whether the image is complex.
+            Whether the image is complex. Set to ``False`` by default.
         expression : a member of :obj:`carta.constants.ArithmeticExpression` or ``None``
             Arithmetic expression to use if opening a complex-valued image. Set to ``None`` if the image is not complex, or to show the default amplitude if the image is complex.
 

--- a/carta/image.py
+++ b/carta/image.py
@@ -42,7 +42,7 @@ class Image:
         self._frame = Macro("", self._base_path)
 
     @classmethod
-    def new(cls, session, path, hdu, append, complex=None):
+    def new(cls, session, path, hdu, append, complex=False, Expression=None):
         """Open or append a new image in the session and return an image object associated with it.
 
         This method should not be used directly. It is wrapped by :obj:`carta.session.Session.open_image` and :obj:`carta.session.Session.append_image`.
@@ -57,7 +57,9 @@ class Image:
             The HDU to open.
         append : boolean
             Whether the image should be appended.
-        complex : a member of :obj:`carta.constants.ArithmeticExpression` or ``None``
+        complex : boolean
+            Whether the image is complex.
+        expression : a member of :obj:`carta.constants.ArithmeticExpression` or ``None``
             Arithmetic expression to use if opening a complex-valued image. Set to ``None`` if the image is not complex, or to show the default amplitude if the image is complex.
 
         Returns
@@ -68,11 +70,13 @@ class Image:
         path = session.resolve_file_path(path)
         directory, file_name = posixpath.split(path)
         command = "appendFile" if append else "openFile"
-        if complex is not None:
-            image_arithmetic = "true"
-            file_name = f'{complex}("{file_name}")'
-        else:
+        if complex is False:
             image_arithmetic = False
+        elif complex is True:
+            image_arithmetic = "true"
+            if Expression is None:
+                Expression = "AMPLITUDE"
+            file_name = f'{Expression}("{file_name}")'
         image_id = session.call_action(command, directory, file_name, hdu, image_arithmetic, return_path="frameInfo.fileId")
         return cls(session, image_id, file_name)
 

--- a/carta/image.py
+++ b/carta/image.py
@@ -42,7 +42,7 @@ class Image:
         self._frame = Macro("", self._base_path)
 
     @classmethod
-    def new(cls, session, path, hdu, append, composite=None):
+    def new(cls, session, path, hdu, append, complex=None):
         """Open or append a new image in the session and return an image object associated with it.
 
         This method should not be used directly. It is wrapped by :obj:`carta.session.Session.open_image` and :obj:`carta.session.Session.append_image`.
@@ -57,6 +57,8 @@ class Image:
             The HDU to open.
         append : boolean
             Whether the image should be appended. By default it is not, and all other open images are closed.
+        complex : None or string
+            Complex value to open a comlex-valued image. The valid options are ``AMPLITUDE``, ``PHASE``, ``REAL`` and ``IMAGINARY``. Default is ``AMPLITUDE``.
 
         Returns
         -------
@@ -65,10 +67,12 @@ class Image:
         """
         path = session.resolve_file_path(path)
         directory, file_name = posixpath.split(path)
-        if composite is not None:
-            file_name = f'{composite}("{file_name}")'
-        image_id = session.call_action("appendFile" if append else "openFile", directory, file_name, hdu, return_path="frameInfo.fileId")
-
+        if complex is not None:
+            file_name = f'{complex}("{file_name}")'
+            image_arithmetic = "true"
+            image_id = session.call_action("appendFile" if append else "openFile", directory, file_name, hdu, image_arithmetic, return_path="frameInfo.fileId")
+        else:
+            image_id = session.call_action("appendFile" if append else "openFile", directory, file_name, hdu, return_path="frameInfo.fileId")
         return cls(session, image_id, file_name)
 
     @classmethod

--- a/carta/image.py
+++ b/carta/image.py
@@ -70,11 +70,11 @@ class Image:
         path = session.resolve_file_path(path)
         directory, file_name = posixpath.split(path)
         command = "appendFile" if append else "openFile"
-        if complex is False:
-            image_arithmetic = False
-        elif complex is True:
-            image_arithmetic = "true"
+        if complex:
+            image_arithmetic = True
             file_name = f'{expression}("{file_name}")'
+        else:
+            image_arithmetic = False
         image_id = session.call_action(command, directory, file_name, hdu, image_arithmetic, return_path="frameInfo.fileId")
         return cls(session, image_id, file_name)
 

--- a/carta/image.py
+++ b/carta/image.py
@@ -42,7 +42,7 @@ class Image:
         self._frame = Macro("", self._base_path)
 
     @classmethod
-    def new(cls, session, path, hdu, append):
+    def new(cls, session, path, hdu, append, composite=None):
         """Open or append a new image in the session and return an image object associated with it.
 
         This method should not be used directly. It is wrapped by :obj:`carta.session.Session.open_image` and :obj:`carta.session.Session.append_image`.
@@ -65,6 +65,8 @@ class Image:
         """
         path = session.resolve_file_path(path)
         directory, file_name = posixpath.split(path)
+        if composite is not None:
+            file_name = f'{composite}("{file_name}")'
         image_id = session.call_action("appendFile" if append else "openFile", directory, file_name, hdu, return_path="frameInfo.fileId")
 
         return cls(session, image_id, file_name)

--- a/carta/image.py
+++ b/carta/image.py
@@ -57,8 +57,8 @@ class Image:
             The HDU to open.
         append : boolean
             Whether the image should be appended. By default it is not, and all other open images are closed.
-        complex : None or string
-            Complex value to open a comlex-valued image. The valid options are ``AMPLITUDE``, ``PHASE``, ``REAL`` and ``IMAGINARY``. Default is ``AMPLITUDE``.
+        complex : a member of :obj:`carta.constants.ArithmeticExpression` or ``None``
+            Arithmetic expression to use if opening a complex-valued image. By default the image is assumed not to be complex.
 
         Returns
         -------
@@ -67,12 +67,13 @@ class Image:
         """
         path = session.resolve_file_path(path)
         directory, file_name = posixpath.split(path)
+        command = "appendFile" if append else "openFile"
         if complex is not None:
-            file_name = f'{complex}("{file_name}")'
             image_arithmetic = "true"
-            image_id = session.call_action("appendFile" if append else "openFile", directory, file_name, hdu, image_arithmetic, return_path="frameInfo.fileId")
+            file_name = f'{complex}("{file_name}")'
         else:
-            image_id = session.call_action("appendFile" if append else "openFile", directory, file_name, hdu, return_path="frameInfo.fileId")
+            image_arithmetic = False
+        image_id = session.call_action(command, directory, file_name, hdu, image_arithmetic, return_path="frameInfo.fileId")
         return cls(session, image_id, file_name)
 
     @classmethod

--- a/carta/session.py
+++ b/carta/session.py
@@ -369,7 +369,7 @@ class Session:
         hdu : {1}
             The HDU to select inside the file.
         complex : {2}
-            Arithmetic expression to use if opening a complex-valued image. A member of :obj:`carta.constants.ArithmeticExpression` or ``None``. By default the image is assumed not to be complex.
+            Arithmetic expression to use if opening a complex-valued image. By default, the amplitude will be shown if the image is complex.
         """
         return Image.new(self, path, hdu, False, complex)
 
@@ -384,7 +384,7 @@ class Session:
         hdu : {1}
             The HDU to select inside the file.
         complex : {2}
-            Arithmetic expression to use if appending a complex-valued image. A member of :obj:`carta.constants.ArithmeticExpression` or ``None``. By default the image is assumed not to be complex.
+            Arithmetic expression to use if appending a complex-valued image. By default, the amplitude will be shown if the image is complex.
         """
         return Image.new(self, path, hdu, True, complex)
 

--- a/carta/session.py
+++ b/carta/session.py
@@ -369,7 +369,7 @@ class Session:
         hdu : {1}
             The HDU to select inside the file.
         complex : {2}
-            Whether the image is complex.
+            Whether the image is complex. Set to ``False`` by default.
         expression : {3}
             Arithmetic expression to use if opening a complex-valued image. By default, the amplitude will be shown if the image is complex.
         """
@@ -386,7 +386,7 @@ class Session:
         hdu : {1}
             The HDU to select inside the file.
         complex : {2}
-            Whether the image is complex.
+            Whether the image is complex. Set to ``False`` by default.
         expression : {3}
             Arithmetic expression to use if appending a complex-valued image. By default, the amplitude will be shown if the image is complex.
         """

--- a/carta/session.py
+++ b/carta/session.py
@@ -358,8 +358,8 @@ class Session:
 
     # IMAGES
 
-    @validate(String(), String(r"\d*"), Boolean(), NoneOr(Constant(ArithmeticExpression)))
-    def open_image(self, path, hdu="", complex=False, expression=None):
+    @validate(String(), String(r"\d*"), Boolean(), Constant(ArithmeticExpression))
+    def open_image(self, path, hdu="", complex=False, expression=ArithmeticExpression.AMPLITUDE):
         """Open a new image, replacing any existing images.
 
         Parameters
@@ -371,12 +371,12 @@ class Session:
         complex : {2}
             Whether the image is complex. Set to ``False`` by default.
         expression : {3}
-            Arithmetic expression to use if opening a complex-valued image. By default, the amplitude will be shown if the image is complex.
+            Arithmetic expression to use if opening a complex-valued image. The default is :obj:`carta.constants.ArithmeticExpression.AMPLITUDE`.
         """
         return Image.new(self, path, hdu, False, complex, expression)
 
-    @validate(String(), String(r"\d*"), Boolean(), NoneOr(Constant(ArithmeticExpression)))
-    def append_image(self, path, hdu="", complex=False, expression=None):
+    @validate(String(), String(r"\d*"), Boolean(), Constant(ArithmeticExpression))
+    def append_image(self, path, hdu="", complex=False, expression=ArithmeticExpression.AMPLITUDE):
         """Append a new image, keeping any existing images.
 
         Parameters
@@ -388,7 +388,7 @@ class Session:
         complex : {2}
             Whether the image is complex. Set to ``False`` by default.
         expression : {3}
-            Arithmetic expression to use if appending a complex-valued image. By default, the amplitude will be shown if the image is complex.
+            Arithmetic expression to use if appending a complex-valued image. The default is :obj:`carta.constants.ArithmeticExpression.AMPLITUDE`.
         """
         return Image.new(self, path, hdu, True, complex, expression)
 

--- a/carta/session.py
+++ b/carta/session.py
@@ -9,7 +9,7 @@ Alternatively, the user can create a new session which runs in a headless browse
 import base64
 
 from .image import Image
-from .constants import CoordinateSystem, LabelType, BeamType, PaletteColor, Overlay, ComplexValue
+from .constants import CoordinateSystem, LabelType, BeamType, PaletteColor, Overlay, ArithmeticExpression
 from .backend import Backend
 from .protocol import Protocol
 from .util import logger, Macro, split_action_path, CartaBadID, CartaBadSession, CartaBadUrl
@@ -358,7 +358,7 @@ class Session:
 
     # IMAGES
 
-    @validate(String(), String(r"\d*"), NoneOr(Constant(ComplexValue)))
+    @validate(String(), String(r"\d*"), NoneOr(Constant(ArithmeticExpression)))
     def open_image(self, path, hdu="", complex=None):
         """Open a new image, replacing any existing images.
 
@@ -369,11 +369,11 @@ class Session:
         hdu : {1}
             The HDU to select inside the file.
         complex : {2}
-            Complex value to open a comlex-valued image. The valid options are ``AMPLITUDE``, ``PHASE``, ``REAL`` and ``IMAGINARY``. Default is ``AMPLITUDE``.
+            Arithmetic expression to use if opening a complex-valued image. A member of :obj:`carta.constants.ArithmeticExpression` or ``None``. By default the image is assumed not to be complex.
         """
         return Image.new(self, path, hdu, False, complex)
 
-    @validate(String(), String(r"\d*"), NoneOr(Constant(ComplexValue)))
+    @validate(String(), String(r"\d*"), NoneOr(Constant(ArithmeticExpression)))
     def append_image(self, path, hdu="", complex=None):
         """Append a new image, keeping any existing images.
 
@@ -384,7 +384,7 @@ class Session:
         hdu : {1}
             The HDU to select inside the file.
         complex : {2}
-            Complex value to append a comlex-valued image. The valid options are ``AMPLITUDE``, ``PHASE``, ``REAL`` and ``IMAGINARY``. Default is ``AMPLITUDE``.
+            Arithmetic expression to use if appending a complex-valued image. A member of :obj:`carta.constants.ArithmeticExpression` or ``None``. By default the image is assumed not to be complex.
         """
         return Image.new(self, path, hdu, True, complex)
 

--- a/carta/session.py
+++ b/carta/session.py
@@ -358,8 +358,8 @@ class Session:
 
     # IMAGES
 
-    @validate(String(), String(r"\d*"), NoneOr(String()))
-    def open_image(self, path, hdu="", composite=None):
+    @validate(String(), String(r"\d*"), NoneOr(OneOf("AMPLITUDE", "PHASE", "REAL", "IMAGINARY")))
+    def open_image(self, path, hdu="", complex=None):
         """Open a new image, replacing any existing images.
 
         Parameters
@@ -368,11 +368,13 @@ class Session:
             The path to the image file, either relative to the session's current directory or an absolute path relative to the CARTA backend's root directory.
         hdu : {1}
             The HDU to select inside the file.
+        complex : {2}
+            Complex value to open a comlex-valued image. The valid options are ``AMPLITUDE``, ``PHASE``, ``REAL`` and ``IMAGINARY``. Default is ``AMPLITUDE``.
         """
-        return Image.new(self, path, hdu, False, composite)
+        return Image.new(self, path, hdu, False, complex)
 
-    @validate(String(), String(r"\d*"), NoneOr(String()))
-    def append_image(self, path, hdu="", composite=None):
+    @validate(String(), String(r"\d*"), NoneOr(OneOf("AMPLITUDE", "PHASE", "REAL", "IMAGINARY")))
+    def append_image(self, path, hdu="", complex=None):
         """Append a new image, keeping any existing images.
 
         Parameters
@@ -381,8 +383,10 @@ class Session:
             The path to the image file, either relative to the session's current directory or an absolute path relative to the CARTA backend's root directory.
         hdu : {1}
             The HDU to select inside the file.
+        complex : {2}
+            Complex value to append a comlex-valued image. The valid options are ``AMPLITUDE``, ``PHASE``, ``REAL`` and ``IMAGINARY``. Default is ``AMPLITUDE``.
         """
-        return Image.new(self, path, hdu, True, composite)
+        return Image.new(self, path, hdu, True, complex)
 
     def image_list(self):
         """Return the list of currently open images.

--- a/carta/session.py
+++ b/carta/session.py
@@ -358,8 +358,8 @@ class Session:
 
     # IMAGES
 
-    @validate(String(), String(r"\d*"), NoneOr(Constant(ArithmeticExpression)))
-    def open_image(self, path, hdu="", complex=None):
+    @validate(String(), String(r"\d*"), Boolean(), NoneOr(Constant(ArithmeticExpression)))
+    def open_image(self, path, hdu="", complex=False, expression=None):
         """Open a new image, replacing any existing images.
 
         Parameters
@@ -369,12 +369,14 @@ class Session:
         hdu : {1}
             The HDU to select inside the file.
         complex : {2}
+            Whether the image is complex.
+        expression : {3}
             Arithmetic expression to use if opening a complex-valued image. By default, the amplitude will be shown if the image is complex.
         """
-        return Image.new(self, path, hdu, False, complex)
+        return Image.new(self, path, hdu, False, complex, expression)
 
-    @validate(String(), String(r"\d*"), NoneOr(Constant(ArithmeticExpression)))
-    def append_image(self, path, hdu="", complex=None):
+    @validate(String(), String(r"\d*"), Boolean(), NoneOr(Constant(ArithmeticExpression)))
+    def append_image(self, path, hdu="", complex=False, expression=None):
         """Append a new image, keeping any existing images.
 
         Parameters
@@ -384,9 +386,11 @@ class Session:
         hdu : {1}
             The HDU to select inside the file.
         complex : {2}
+            Whether the image is complex.
+        expression : {3}
             Arithmetic expression to use if appending a complex-valued image. By default, the amplitude will be shown if the image is complex.
         """
-        return Image.new(self, path, hdu, True, complex)
+        return Image.new(self, path, hdu, True, complex, expression)
 
     def image_list(self):
         """Return the list of currently open images.

--- a/carta/session.py
+++ b/carta/session.py
@@ -9,7 +9,7 @@ Alternatively, the user can create a new session which runs in a headless browse
 import base64
 
 from .image import Image
-from .constants import CoordinateSystem, LabelType, BeamType, PaletteColor, Overlay
+from .constants import CoordinateSystem, LabelType, BeamType, PaletteColor, Overlay, ComplexValue
 from .backend import Backend
 from .protocol import Protocol
 from .util import logger, Macro, split_action_path, CartaBadID, CartaBadSession, CartaBadUrl
@@ -358,7 +358,7 @@ class Session:
 
     # IMAGES
 
-    @validate(String(), String(r"\d*"), NoneOr(OneOf("AMPLITUDE", "PHASE", "REAL", "IMAGINARY")))
+    @validate(String(), String(r"\d*"), NoneOr(Constant(ComplexValue)))
     def open_image(self, path, hdu="", complex=None):
         """Open a new image, replacing any existing images.
 
@@ -373,7 +373,7 @@ class Session:
         """
         return Image.new(self, path, hdu, False, complex)
 
-    @validate(String(), String(r"\d*"), NoneOr(OneOf("AMPLITUDE", "PHASE", "REAL", "IMAGINARY")))
+    @validate(String(), String(r"\d*"), NoneOr(Constant(ComplexValue)))
     def append_image(self, path, hdu="", complex=None):
         """Append a new image, keeping any existing images.
 

--- a/carta/session.py
+++ b/carta/session.py
@@ -358,8 +358,8 @@ class Session:
 
     # IMAGES
 
-    @validate(String(), String(r"\d*"))
-    def open_image(self, path, hdu=""):
+    @validate(String(), String(r"\d*"), NoneOr(String()))
+    def open_image(self, path, hdu="", composite=None):
         """Open a new image, replacing any existing images.
 
         Parameters
@@ -369,10 +369,10 @@ class Session:
         hdu : {1}
             The HDU to select inside the file.
         """
-        return Image.new(self, path, hdu, False)
+        return Image.new(self, path, hdu, False, composite)
 
-    @validate(String(), String(r"\d*"))
-    def append_image(self, path, hdu=""):
+    @validate(String(), String(r"\d*"), NoneOr(String()))
+    def append_image(self, path, hdu="", composite=None):
         """Append a new image, keeping any existing images.
 
         Parameters
@@ -382,7 +382,7 @@ class Session:
         hdu : {1}
             The HDU to select inside the file.
         """
-        return Image.new(self, path, hdu, True)
+        return Image.new(self, path, hdu, True, composite)
 
     def image_list(self):
         """Return the list of currently open images.


### PR DESCRIPTION
This PR is to resolve #89.

@confluence, I bump into some problems when dealing with this issue:
I found that I can open a composite image with the script like:
```
img = session.call_action("openFile", "/media/icchen/disk/fits/", 'PHASE("complex.image")', "", "true", return_path="frameInfo.fileId")
```
Note that the `'PHASE("complex. Image")'` is at the position of `file_name`. Thus, in 2505e12, I added an argument `composite` to `new` of `image.py` and `open_image` and `append_image` of `session.py` to create new `file_name` if `composite` is not `None` (I haven't write the description for the argument, just make a test first).Then I tried to write a test script like:
```
img = session.open_image("/media/icchen/disk/fits/complex.image", composite="PHASE")
```
but got an message like:
```
-build/venv_carta-python/bin/python /home/icchen/Python_wrappers/test.py
Traceback (most recent call last):
  File "/home/icchen/Python_wrappers/test.py", line 16, in <module>
    img = session.open_image("/media/icchen/disk/fits/complex.image", composite="PHASE")
  File "/home/icchen/carta-build/venv_carta-python/lib/python3.10/site-packages/carta/validation.py", line 634, in newfunc
    return func(self, *args, **kwargs)
  File "/home/icchen/carta-build/venv_carta-python/lib/python3.10/site-packages/carta/session.py", line 372, in open_image
    return Image.new(self, path, hdu, False, composite)
  File "/home/icchen/carta-build/venv_carta-python/lib/python3.10/site-packages/carta/image.py", line 70, in new
    image_id = session.call_action("appendFile" if append else "openFile", directory, file_name, hdu, return_path="frameInfo.fileId")
  File "/home/icchen/carta-build/venv_carta-python/lib/python3.10/site-packages/carta/session.py", line 254, in call_action
    return self._protocol.request_scripting_action(self.session_id, path, *args, **kwargs)
  File "/home/icchen/carta-build/venv_carta-python/lib/python3.10/site-packages/carta/protocol.py", line 372, in request_scripting_action
    raise CartaActionFailed(f"{carta_action_description} failed: {response_data.get('message', 'No error message received.')}")
carta.util.CartaActionFailed: CARTA scripting action .openFile called with parameters ('/media/icchen/disk/fits', 'PHASE("complex. Image")', '') failed: File PHASE("complex.image") does not exist.
```
Note that in the last line it says
```
CARTA scripting action .openFile called with parameters ('/media/icchen/disk/fits', 'PHASE("complex.image")', '') failed: File PHASE("complex.image") does not exist.
```
but `PHASE("complex.image")` is exactly what I input with the script that I successfully open the composite image:
```
img = session.call_action("openFile", "/media/icchen/disk/fits/", 'PHASE("complex. Image")', "", "true", return_path="frameInfo.fileId")
```
Do you have idea why this `composite` string I create is not able to be recognized as a file when using `open_image`?

p.s. I have recorded a video for your reference:
[Screencast from 04-10-2023 12:19:51 PM.webm](https://user-images.githubusercontent.com/106953609/230826543-beae70b6-f8de-4751-ba7e-566b93a2c03e.webm)
