### PR TITLE
Add step and offset parameters to the Number validator to allow discrete numeric ranges

### DIFF
--- a/carta/image.py
+++ b/carta/image.py
@@ -131,7 +131,7 @@ class Image:
         return self.session.get_value(f"{self._base_path}.{path}")
 
     def macro(self, target, variable):
-        """Convenience wrapper for creating a :obj:carta.util.Macro for an image property.
+        """Convenience wrapper for creating a :obj:`carta.util.Macro` for an image property.
 
         This method prepends this image's base path to the *target* parameter. If *target* is the empty string, the base path will be substituted.
 

--- a/carta/image.py
+++ b/carta/image.py
@@ -133,7 +133,7 @@ class Image:
     def macro(self, target, variable):
         """Convenience wrapper for creating a :obj:carta.util.Macro for an image property.
 
-        This method prepends this image's base path to the *target* parameter.
+        This method prepends this image's base path to the *target* parameter. If *target* is the empty string, the base path will be substituted.
 
         Parameters
         ----------
@@ -147,7 +147,8 @@ class Image:
         :obj:carta.util.Macro
             A placeholder for a variable which will be evaluated dynamically by the frontend.
         """
-        return Macro(f"{self._base_path}.{target}", variable)
+        target = f"{self._base_path}.{target}" if target else self._base_path
+        return Macro(target, variable)
 
     # METADATA
 
@@ -394,16 +395,11 @@ class Image:
         Parameters
         ----------
         channel : {0}
-            The desired channel. Defaults to the current channel.
+            The desired channel.
         recursive : {1}
             Whether to perform the same change on all spectrally matched images. Defaults to True.
         """
-        polarization = self.get_value("requiredPolarization")
-
-        if polarization < Polarization.PTOTAL:
-            polarization = self.polarizations.index(polarization)
-
-        self.call_action("setChannels", channel, polarization, recursive)
+        self.call_action("setChannels", channel, self.macro("", "requiredStokes"), recursive)
 
     @validate(Evaluate(OneOf, Attrs("polarizations")), Boolean())
     def set_polarization(self, polarization, recursive=True):
@@ -412,16 +408,14 @@ class Image:
         Parameters
         ----------
         polarization : {0}
-            The desired polarization. Defaults to the current polarization.
+            The desired polarization.
         recursive : {1}
             Whether to perform the same change on all spectrally matched images. Defaults to True.
         """
-        channel = self.get_value("requiredChannel")
-
         if polarization < Polarization.PTOTAL:
             polarization = self.polarizations.index(polarization)
 
-        self.call_action("setChannels", channel, polarization, recursive)
+        self.call_action("setChannels", self.macro("", "requiredChannel"), polarization, recursive)
 
     @validate(Number(), Number())
     def set_center(self, x, y):

--- a/carta/image.py
+++ b/carta/image.py
@@ -388,7 +388,7 @@ class Image:
 
     # NAVIGATION
 
-    @validate(Evaluate(Number, 0, Attr("depth"), Number.INCLUDE_MIN), Boolean())
+    @validate(Evaluate(Number, 0, Attr("depth"), Number.INCLUDE_MIN, step=1), Boolean())
     def set_channel(self, channel, recursive=True):
         """Set the channel.
 

--- a/carta/validation.py
+++ b/carta/validation.py
@@ -101,6 +101,10 @@ class Number(Parameter):
         The upper bound.
     interval : int
         A bitmask which describes whether the bounds are included or excluded. The constant attributes defined on this class should be used. By default both bounds are included.
+    step : number, optional
+        A step size to which the value must conform. May be a fractional value. If this is unset, any value within the range is permitted.
+    offset : number, optional
+        A step offset. Ignored if a step size is not set. By default permitted values are aligned with the lower bound if it is set, otherwise with zero.
 
     Attributes
     ----------
@@ -112,15 +116,30 @@ class Number(Parameter):
         Whether the lower bound is included.
     max_included : bool
         Whether the upper bound is included.
+    step : number, optional
+        The step size.
+    offset : number, optional
+        The step offset.
     """
 
     EXCLUDE, INCLUDE_MIN, INCLUDE_MAX, INCLUDE = range(4)
 
-    def __init__(self, min=None, max=None, interval=INCLUDE):
+    def __init__(self, min=None, max=None, interval=INCLUDE, step=None, offset=None):
         self.min = min
         self.max = max
         self.min_included = bool(interval & self.INCLUDE_MIN)
         self.max_included = bool(interval & self.INCLUDE_MAX)
+        if step is not None:
+            self.step = step
+            if offset is not None:
+                self.offset = offset
+            elif min is not None:
+                self.offset = min
+            else:
+                self.offset = 0
+        else:
+            self.step = None
+            self.offset = None
 
     def validate(self, value, parent):
         """Check if the value is a number and falls within any bounds that were provided.
@@ -154,6 +173,10 @@ class Number(Parameter):
                 if value > self.max:
                     raise ValueError(f"{value} is greater than upper bound {self.max}, but must be smaller.")
 
+        if self.step is not None:
+            if (value - self.offset) % self.step:
+                raise ValueError(f"{value} is not an increment of {self.step} offset by {self.offset}.")
+
     @property
     def description(self):
         """A human-readable description of this parameter descriptor.
@@ -173,6 +196,9 @@ class Number(Parameter):
 
         if self.max is not None:
             desc.append(f"smaller than{' or equal to' if self.max_included else ''} ``{self.max}``")
+
+        if self.step is not None:
+            desc.append(f"in increments of {self.step} starting from {self.offset}")
 
         return " ".join(desc)
 


### PR DESCRIPTION
This should make it possible to use the `Number` validator to validate discrete number ranges with a fixed step size and offset. It should not affect existing usage of the validator. Validation doesn't check *type* -- if `1` is a valid value, so is `1.0`.