### PR TITLE
Use Number for number ranges. Tweak offset logic.

### DIFF
--- a/carta/session.py
+++ b/carta/session.py
@@ -443,7 +443,7 @@ class Session:
         """Go to next page in viewer."""
         self.call_action("widgetsStore.onNextPageClick")
 
-    @validate(OneOf(*range(1, 11)), OneOf(*range(1, 11)), Constant(GridMode))
+    @validate(Number(1, 10, step=1), Number(1, 10, step=1), Constant(GridMode))
     def set_viewer_grid(self, rows, columns, grid_mode=GridMode.FIXED):
         """
         Set number of columns and rows in viewer grid.

--- a/carta/validation.py
+++ b/carta/validation.py
@@ -134,7 +134,7 @@ class Number(Parameter):
             if offset is not None:
                 self.offset = offset
             elif min is not None:
-                self.offset = min
+                self.offset = min % step
             else:
                 self.offset = 0
         else:


### PR DESCRIPTION
I merged the viewer grid PR before I merged the `Number` feature. This changes the validators on `set_viewer_grid` from `OneOf` to `Number`.

I have also tweaked the `Number` logic so that if a lower bound is set the default offset is the lower bound *modulo the step size* -- this avoids a confusing error message from the validator if e.g. the lower bound is an exact multiple of the step size (in which case the offset should be zero). This should have no effect on the validation maths; it should just normalize the offset value.