### PR TITLE
Removed unnecessary backticks from description for String validator with regex

### DIFF
--- a/carta/validation.py
+++ b/carta/validation.py
@@ -86,7 +86,7 @@ class String(Parameter):
             The description.
         """
         if self.regex:
-            return f"`a string matching` ``{self.regex}``"
+            return f"a string matching ``{self.regex}``"
         return "a string"
 
 


### PR DESCRIPTION
This is a simple fix which only affects the documentation.