### PR TITLE
Validation and serialization improvements

### DIFF
--- a/carta/image.py
+++ b/carta/image.py
@@ -5,7 +5,7 @@ Image objects should not be instantiated directly, and should only be created th
 import posixpath
 
 from .constants import Colormap, Scaling, SmoothingMode, ContourDashMode, Polarization
-from .util import logger, Macro, cached
+from .util import Macro, cached
 from .validation import validate, Number, Color, Constant, Boolean, NoneOr, IterableOf, Evaluate, Attr, Attrs, OneOf
 
 

--- a/carta/util.py
+++ b/carta/util.py
@@ -85,14 +85,18 @@ class Macro:
     def __repr__(self):
         return f"Macro('{self.target}', '{self.variable}')"
 
+    def json(self):
+        """The JSON serialization of this object."""
+        return {"macroTarget": self.target, "macroVariable": self.variable}
+
 
 class CartaEncoder(json.JSONEncoder):
-    """A custom encoder to JSON which correctly serialises :obj:`carta.util.Macro` objects and numpy arrays."""
+    """A custom encoder to JSON which correctly serialises custom objects with a ``json`` method, and numpy arrays."""
 
     def default(self, obj):
         """ This method is overridden from the parent class and performs the substitution."""
-        if isinstance(obj, Macro):
-            return {"macroTarget": obj.target, "macroVariable": obj.variable}
+        if hasattr(obj, "json") and callable(obj.json):
+            return obj.json()
         if type(obj).__module__ == "numpy" and type(obj).__name__ == "ndarray":
             # The condition is a workaround to avoid importing numpy
             return obj.tolist()

--- a/carta/validation.py
+++ b/carta/validation.py
@@ -469,21 +469,32 @@ class IterableOf(Parameter):
     ----------
     param : :obj:`carta.validation.Parameter`
         The parameter descriptor.
+    min_size : integer, optional
+        The minimum size.
+    max_size : integer, optional
+        The maximum size.
 
     Attributes
     ----------
     param : :obj:`carta.validation.Parameter`
         The parameter descriptor.
+    min_size : integer, optional
+        The minimum size.
+    max_size : integer, optional
+        The maximum size.
     """
 
-    def __init__(self, param):
+    def __init__(self, param, min_size=None, max_size=None):
         self.param = param
+        self.min_size = min_size
+        self.max_size = max_size
 
     def validate(self, value, parent):
         """Check if each element of the iterable can be validated with the given descriptor.
 
         See :obj:`carta.validation.Parameter.validate` for general information about this method.
         """
+
         try:
             for v in value:
                 self.param.validate(v, parent)
@@ -491,6 +502,14 @@ class IterableOf(Parameter):
             if str(e).endswith("object is not iterable"):
                 raise ValueError(f"{value} is not iterable, but {self.description} was expected.")
             raise e
+
+        if self.min_size is not None:
+            if len(value) < self.min_size:
+                raise ValueError(f"{value} has {len(value)} elements, but must have at least {self.min_size}.")
+
+        if self.max_size is not None:
+            if len(value) > self.max_size:
+                raise ValueError(f"{value} has {len(value)} elements, but may have at most {self.max_size}.")
 
     @property
     def description(self):
@@ -501,7 +520,17 @@ class IterableOf(Parameter):
         string
             The description.
         """
-        return f"an iterable in which each element is {self.param.description}"
+        size = []
+        size_desc = ""
+
+        if self.min_size is not None:
+            size.append(f"at least {self.min_size} elements")
+        if self.max_size is not None:
+            size.append(f"at most {self.max_size} elements")
+
+        if size:
+            size_desc = f"with {' and '.join(size)} "
+        return f"an iterable {size_desc}in which each element is {self.param.description}"
 
 
 COLORNAMES = ('aliceblue', 'antiquewhite', 'aqua', 'aquamarine', 'azure', 'beige', 'bisque', 'black', 'blanchedalmond', 'blue', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgrey', 'darkgreen', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'fuchsia', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'gray', 'grey', 'green', 'greenyellow', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgrey', 'lightgreen', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'lime', 'limegreen', 'linen', 'magenta', 'maroon', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'navy', 'oldlace', 'olive', 'olivedrab', 'orange', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'purple', 'red', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'silver', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan', 'teal', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'white', 'whitesmoke', 'yellow', 'yellowgreen')


### PR DESCRIPTION
This PR:

* Adds a new `InstanceOf` validator which just checks the value against a type or tuple of types (using `isinstance` under the hood).
* Fixes the `IterableOf` validator to add a more specific error message if the value isn't iterable at all, and to make the description more readable
* Moves the macro-specific serialization logic from the serializer to the `Macro` object. Any custom object with a `json` method will now use that method for serialization.