### PR TITLE
Icchen/91 load image via lel

### DIFF
--- a/carta/constants.py
+++ b/carta/constants.py
@@ -10,8 +10,8 @@ except ImportError:
         pass
 
 
-class ComplexExpression(StrEnum):
-    """Complex expression."""
+class ComplexComponent(StrEnum):
+    """Complex component."""
     AMPLITUDE = "AMPLITUDE"
     PHASE = "PHASE"
     REAL = "REAL"

--- a/carta/constants.py
+++ b/carta/constants.py
@@ -5,7 +5,7 @@ from enum import Enum, IntEnum
 
 # TODO make sure the __str__ is right for all the string values
 
-class ArithmeticExpression(str, Enum):
+class ComplexExpression(str, Enum):
     """Arithmetic expression."""
     AMPLITUDE = "AMPLITUDE"
     PHASE = "PHASE"

--- a/carta/constants.py
+++ b/carta/constants.py
@@ -6,7 +6,7 @@ from enum import Enum, IntEnum
 # TODO make sure the __str__ is right for all the string values
 
 class ComplexExpression(str, Enum):
-    """Arithmetic expression."""
+    """Complex expression."""
     AMPLITUDE = "AMPLITUDE"
     PHASE = "PHASE"
     REAL = "REAL"

--- a/carta/image.py
+++ b/carta/image.py
@@ -6,7 +6,7 @@ import posixpath
 
 from .constants import Colormap, Scaling, SmoothingMode, ContourDashMode, Polarization
 from .util import Macro, cached
-from .validation import validate, Number, Color, Constant, Boolean, NoneOr, IterableOf, Evaluate, Attr, Attrs, OneOf
+from .validation import validate, Number, Color, Constant, Boolean, NoneOr, IterableOf, Evaluate, Attr, Attrs, OneOf, String
 
 
 class Image:
@@ -42,25 +42,26 @@ class Image:
         self._frame = Macro("", self._base_path)
 
     @classmethod
+    @validate(String(), String(), String(), Boolean(), Boolean())
     def new(cls, session, directory, file_name, hdu, append, image_arithmetic):
         """Open or append a new image in the session and return an image object associated with it.
 
-        This method should not be used directly. It is wrapped by :obj:`carta.session.Session.open_image`, :obj:`carta.session.Session.open_complex_image` and :obj:`carta.session.Session.open_complex_image`.
+        This method should not be used directly. It is wrapped by :obj:`carta.session.Session.open_image`, :obj:`carta.session.Session.open_complex_image` and :obj:`carta.session.Session.open_LEL_image`.
 
         Parameters
         ----------
         session : :obj:`carta.session.Session`
             The session object.
-        directory : string
-            The directory to the image file, either relative to the session's current directory or an absolute path relative to the CARTA backend's root directory.
-        file_name : string
-            The name of the image file or the LEL expression for complex image and arithmeic image.
-        hdu : string
+        directory : {0}
+            The directory containing the image file, or the base directory for the LEL arithmetic expression, as an absolute path relative to the CARTA backend's root directory.
+        file_name : {1}
+            The name of the image file, or a LEL arithmetic expression.
+        hdu : {2}
             The HDU to open.
-        append : boolean
+        append : {3}
             Whether the image should be appended.
-        image_arihmetic : boolean
-            Whether the LEL expression is used.
+        image_arihmetic : {4}
+            Whether the file name should be interpreted as a LEL expression.
 
         Returns
         -------

--- a/carta/image.py
+++ b/carta/image.py
@@ -42,7 +42,7 @@ class Image:
         self._frame = Macro("", self._base_path)
 
     @classmethod
-    def new(cls, session, directory, file_name, hdu, append, image_arithmetic, make_active=True, update_directory=False):
+    def new(cls, session, path, hdu, append, complex, image_arithmetic, expression, make_active=True, update_directory=False):
         """Open or append a new image in the session and return an image object associated with it.
 
         This method should not be used directly. It is wrapped by :obj:`carta.session.Session.open_image`, :obj:`carta.session.Session.open_complex_image` and :obj:`carta.session.Session.open_LEL_image`.
@@ -51,16 +51,18 @@ class Image:
         ----------
         session : :obj:`carta.session.Session`
             The session object.
-        directory : string
-            The directory containing the image file, or the base directory for the LEL arithmetic expression, as an absolute path relative to the CARTA backend's root directory.
-        file_name : string
-            The name of the image file, or a LEL arithmetic expression.
+        path : string
+            The path to the image file, either relative to the session's current directory or an absolute path relative to the CARTA backend's root directory.
         hdu : string
             The HDU to open.
         append : boolean
             Whether the image should be appended.
+        complex : boolean
+            Whether the image is complex.
         image_arihmetic : boolean
-            Whether the file name should be interpreted as a LEL expression. Ignored if the image is not complex.
+            Whether the file name should be interpreted as a complex expression or a LEL expression.
+        expression : string
+            The name of the image file, or a LEL arithmetic expression.
         make_active : boolean
             Whether the image should be made active in the frontend. This only applies if an image is being appended. The default is ``True``.
         update_directory : boolean
@@ -72,6 +74,14 @@ class Image:
             A new image object.
         """
         command = "appendFile" if append else "openFile"
+
+        path = session.resolve_file_path(path)
+        directory, file_name = posixpath.split(path)
+
+        if complex and image_arithmetic:
+            file_name = f'{expression}("{file_name}")'
+        elif not complex and image_arithmetic:
+            file_name = expression
 
         params = [directory, file_name, hdu, image_arithmetic]
         if append:

--- a/carta/image.py
+++ b/carta/image.py
@@ -42,42 +42,32 @@ class Image:
         self._frame = Macro("", self._base_path)
 
     @classmethod
-    def new(cls, session, path, hdu, append, complex, expression):
+    def new(cls, session, directory, file_name, hdu, append, image_arithmetic):
         """Open or append a new image in the session and return an image object associated with it.
 
-        This method should not be used directly. It is wrapped by :obj:`carta.session.Session.open_image` and :obj:`carta.session.Session.append_image`.
+        This method should not be used directly. It is wrapped by :obj:`carta.session.Session.open_image`, :obj:`carta.session.Session.open_complex_image` and :obj:`carta.session.Session.open_complex_image`.
 
         Parameters
         ----------
         session : :obj:`carta.session.Session`
             The session object.
-        path : string
-            The path to the image file, either relative to the session's current directory or an absolute path relative to the CARTA backend's root directory.
+        directory : string
+            The directory to the image file, either relative to the session's current directory or an absolute path relative to the CARTA backend's root directory.
+        file_name : string
+            The name of the image file or the LEL expression for complex image and arithmeic image.
         hdu : string
             The HDU to open.
         append : boolean
             Whether the image should be appended.
-        complex : boolean
-            Whether the image is complex.
-        expression : string or a member of :obj:`carta.constants.ComplexExpression`
-            Arithmetic expression or complex expression to use if opening a complex-valued image.
+        image_arihmetic : boolean
+            Whether the LEL expression is used.
 
         Returns
         -------
         :obj:`carta.image.Image`
             A new image object.
         """
-        path = session.resolve_file_path(path)
-        directory, file_name = posixpath.split(path)
         command = "appendFile" if append else "openFile"
-        if complex:
-            image_arithmetic = True
-            file_name = f'{expression}("{file_name}")'
-        elif complex is False and file_name == "":
-            image_arithmetic = True
-            file_name = expression
-        else:
-            image_arithmetic = False
         image_id = session.call_action(command, directory, file_name, hdu, image_arithmetic, return_path="frameInfo.fileId")
         return cls(session, image_id, file_name)
 

--- a/carta/image.py
+++ b/carta/image.py
@@ -52,7 +52,7 @@ class Image:
         directory : string
             The directory containing the image file or the base directory for the LEL arithmetic expression, either relative to the session's current directory or an absolute path relative to the CARTA backend's root directory
         file_name : string
-            The name of the image file, or a LEL arithmetic expression.
+            The name of the image file, complex expression or a LEL arithmetic expression.
         hdu : string
             The HDU to open.
         append : boolean

--- a/carta/image.py
+++ b/carta/image.py
@@ -59,7 +59,7 @@ class Image:
             The HDU to open.
         append : boolean
             Whether the image should be appended.
-        image_arihmetic : boolean
+        image_arithmetic : boolean
             Whether the file name should be interpreted as a LEL expression. Ignored if the image is not complex.
         make_active : boolean
             Whether the image should be made active in the frontend. This only applies if an image is being appended. The default is ``True``.
@@ -72,6 +72,7 @@ class Image:
             A new image object.
         """
         command = "appendFile" if append else "openFile"
+        directory = session.resolve_file_path(directory)
 
         params = [directory, file_name, hdu, image_arithmetic]
         if append:

--- a/carta/image.py
+++ b/carta/image.py
@@ -50,7 +50,7 @@ class Image:
         session : :obj:`carta.session.Session`
             The session object.
         directory : string
-            The directory containing the image file, or the base directory for the LEL arithmetic expression, as an absolute path relative to the CARTA backend's root directory.
+            The directory containing the image file or the base directory for the LEL arithmetic expression, either relative to the session's current directory or an absolute path relative to the CARTA backend's root directory
         file_name : string
             The name of the image file, or a LEL arithmetic expression.
         hdu : string
@@ -58,7 +58,7 @@ class Image:
         append : boolean
             Whether the image should be appended.
         image_arithmetic : boolean
-            Whether the file name should be interpreted as a LEL expression. Ignored if the image is not complex.
+            Whether the file name should be interpreted as a complex expression or a LEL expression.
         make_active : boolean
             Whether the image should be made active in the frontend. This only applies if an image is being appended. The default is ``True``.
         update_directory : boolean

--- a/carta/image.py
+++ b/carta/image.py
@@ -42,7 +42,6 @@ class Image:
         self._frame = Macro("", self._base_path)
 
     @classmethod
-    @validate(String(), String(), String(), Boolean(), Boolean())
     def new(cls, session, directory, file_name, hdu, append, image_arithmetic):
         """Open or append a new image in the session and return an image object associated with it.
 
@@ -52,15 +51,15 @@ class Image:
         ----------
         session : :obj:`carta.session.Session`
             The session object.
-        directory : {0}
+        directory : string
             The directory containing the image file, or the base directory for the LEL arithmetic expression, as an absolute path relative to the CARTA backend's root directory.
-        file_name : {1}
+        file_name : string
             The name of the image file, or a LEL arithmetic expression.
-        hdu : {2}
+        hdu : string
             The HDU to open.
-        append : {3}
+        append : boolean
             Whether the image should be appended.
-        image_arihmetic : {4}
+        image_arihmetic : boolean
             Whether the file name should be interpreted as a LEL expression.
 
         Returns

--- a/carta/image.py
+++ b/carta/image.py
@@ -2,11 +2,9 @@
 
 Image objects should not be instantiated directly, and should only be created through methods on the :obj:`carta.session.Session` object.
 """
-import posixpath
-
 from .constants import Colormap, Scaling, SmoothingMode, ContourDashMode, Polarization, CoordinateSystem, SpatialAxis
 from .util import Macro, cached, PixelValue, AngularSize, WorldCoordinate
-from .validation import validate, Number, Color, Constant, Boolean, NoneOr, IterableOf, Evaluate, Attr, Attrs, OneOf, Size, Coordinate, String
+from .validation import validate, Number, Color, Constant, Boolean, NoneOr, IterableOf, Evaluate, Attr, Attrs, OneOf, Size, Coordinate
 
 
 class Image:

--- a/carta/image.py
+++ b/carta/image.py
@@ -42,7 +42,7 @@ class Image:
         self._frame = Macro("", self._base_path)
 
     @classmethod
-    def new(cls, session, path, hdu, append, complex, image_arithmetic, expression, make_active=True, update_directory=False):
+    def new(cls, session, directory, file_name, hdu, append, image_arithmetic, make_active=True, update_directory=False):
         """Open or append a new image in the session and return an image object associated with it.
 
         This method should not be used directly. It is wrapped by :obj:`carta.session.Session.open_image`, :obj:`carta.session.Session.open_complex_image` and :obj:`carta.session.Session.open_LEL_image`.
@@ -51,18 +51,16 @@ class Image:
         ----------
         session : :obj:`carta.session.Session`
             The session object.
-        path : string
-            The path to the image file, either relative to the session's current directory or an absolute path relative to the CARTA backend's root directory.
+        directory : string
+            The directory containing the image file, or the base directory for the LEL arithmetic expression, as an absolute path relative to the CARTA backend's root directory.
+        file_name : string
+            The name of the image file, or a LEL arithmetic expression.
         hdu : string
             The HDU to open.
         append : boolean
             Whether the image should be appended.
-        complex : boolean
-            Whether the image is complex.
         image_arihmetic : boolean
-            Whether the file name should be interpreted as a complex expression or a LEL expression.
-        expression : string
-            The name of the image file, or a LEL arithmetic expression.
+            Whether the file name should be interpreted as a LEL expression. Ignored if the image is not complex.
         make_active : boolean
             Whether the image should be made active in the frontend. This only applies if an image is being appended. The default is ``True``.
         update_directory : boolean
@@ -74,14 +72,6 @@ class Image:
             A new image object.
         """
         command = "appendFile" if append else "openFile"
-
-        path = session.resolve_file_path(path)
-        directory, file_name = posixpath.split(path)
-
-        if complex and image_arithmetic:
-            file_name = f'{expression}("{file_name}")'
-        elif not complex and image_arithmetic:
-            file_name = expression
 
         params = [directory, file_name, hdu, image_arithmetic]
         if append:

--- a/carta/image.py
+++ b/carta/image.py
@@ -52,13 +52,13 @@ class Image:
         directory : string
             The directory containing the image file or the base directory for the LEL arithmetic expression, either relative to the session's current directory or an absolute path relative to the CARTA backend's root directory
         file_name : string
-            The name of the image file, complex expression or a LEL arithmetic expression.
+            The name of the image file, or a LEL arithmetic expression.
         hdu : string
             The HDU to open.
         append : boolean
             Whether the image should be appended.
         image_arithmetic : boolean
-            Whether the file name should be interpreted as a complex expression or a LEL expression.
+            Whether the file name should be interpreted as a LEL expression.
         make_active : boolean
             Whether the image should be made active in the frontend. This only applies if an image is being appended. The default is ``True``.
         update_directory : boolean

--- a/carta/image.py
+++ b/carta/image.py
@@ -50,7 +50,7 @@ class Image:
         session : :obj:`carta.session.Session`
             The session object.
         directory : string
-            The directory containing the image file or the base directory for the LEL arithmetic expression, either relative to the session's current directory or an absolute path relative to the CARTA backend's root directory
+            The directory containing the image file or the base directory for the LEL arithmetic expression, either relative to the session's current directory or an absolute path relative to the CARTA backend's root directory.
         file_name : string
             The name of the image file, or a LEL arithmetic expression.
         hdu : string
@@ -62,7 +62,7 @@ class Image:
         make_active : boolean
             Whether the image should be made active in the frontend. This only applies if an image is being appended. The default is ``True``.
         update_directory : boolean
-            Whether the starting directory of the frontend file browser should be updated to the parent directory of the image. The default is ``False``.
+            Whether the starting directory of the frontend file browser should be updated to the directory provided. The default is ``False``.
 
         Returns
         -------

--- a/carta/image.py
+++ b/carta/image.py
@@ -59,8 +59,8 @@ class Image:
             Whether the image should be appended.
         complex : boolean
             Whether the image is complex.
-        expression : a member of :obj:`carta.constants.ArithmeticExpression`
-            Arithmetic expression to use if opening a complex-valued image.
+        expression : string or a member of :obj:`carta.constants.ComplexExpression`
+            Arithmetic expression or complex expression to use if opening a complex-valued image.
 
         Returns
         -------
@@ -73,6 +73,9 @@ class Image:
         if complex:
             image_arithmetic = True
             file_name = f'{expression}("{file_name}")'
+        elif complex is False and file_name == "":
+            image_arithmetic = True
+            file_name = expression
         else:
             image_arithmetic = False
         image_id = session.call_action(command, directory, file_name, hdu, image_arithmetic, return_path="frameInfo.fileId")

--- a/carta/session.py
+++ b/carta/session.py
@@ -370,7 +370,7 @@ class Session:
         hdu : {1}
             The HDU to select inside the file.
         append : {2}
-            Whether the image should be appended. Default is ``False``.
+            Whether the image should be appended to existing images. By default this is ``False`` and any existing open images are closed.
         """
         path = self.resolve_file_path(path)
         directory, file_name = posixpath.split(path)
@@ -385,9 +385,9 @@ class Session:
         path : {0}
             The path to the complex-valued image file, either relative to the session's current directory or an absolute path relative to the CARTA backend's root directory.
         expression : {1}
-            The complex expression for opening a complex-valued image.
+            The complex expression for opening a complex-valued image. The default is :obj:`carta.constants.ComplexExpression.AMPLITUDE`.
         append : {2}
-            Whether the image should be appended. Default is ``False``.
+            Whether the image should be appended to existing images. By default this is ``False`` and any existing open images are closed.
         """
         path = self.resolve_file_path(path)
         directory, file_name = posixpath.split(path)
@@ -405,7 +405,7 @@ class Session:
         directory : {1}
             The base directory for the LEL expression, either relative to the session's current directory or an absolute path relative to the CARTA backend's root directory. Defaults to the session's current directory.
         append : {2}
-            Whether the image should be appended. Default is ``False``.
+            Whether the image should be appended to existing images. By default this is ``False`` and any existing open images are closed.
         """
         if directory is None:
             directory = self.pwd()

--- a/carta/session.py
+++ b/carta/session.py
@@ -355,7 +355,6 @@ class Session:
         update_directory : {3}
             Whether the starting directory of the frontend file browser should be updated to the parent directory of the image. The default is ``False``.
         """
-        path = self.resolve_file_path(path)
         directory, file_name = posixpath.split(path)
         return Image.new(self, directory, file_name, hdu, append, False, update_directory=update_directory)
 
@@ -374,7 +373,6 @@ class Session:
         update_directory : {3}
             Whether the starting directory of the frontend file browser should be updated to the parent directory of the image. The default is ``False``.
         """
-        path = self.resolve_file_path(path)
         directory, file_name = posixpath.split(path)
         expression = f'{expression}("{file_name}")'
         return Image.new(self, directory, expression, "", append, True, update_directory=update_directory)
@@ -394,7 +392,6 @@ class Session:
         update_directory : {3}
             Whether the starting directory of the frontend file browser should be updated to the parent directory of the image. The default is ``False``.
         """
-        directory = self.resolve_file_path(directory)
         return Image.new(self, directory, expression, "", append, True, update_directory=update_directory)
 
     def image_list(self):

--- a/carta/session.py
+++ b/carta/session.py
@@ -393,11 +393,11 @@ class Session:
         """
         path = self.resolve_file_path(path)
         directory, file_name = posixpath.split(path)
-        file_name = f'{expression}("{file_name}")'
-        return Image.new(self, directory, file_name, hdu, append, True)
+        expression = f'{expression}("{file_name}")'
+        return Image.new(self, directory, expression, hdu, append, True)
 
     @validate(String(), String(), String(r"\d*"), Boolean())
-    def open_LEL_image(self, expression, directory, hdu="", append=False):
+    def open_LEL_image(self, expression, directory=None, hdu="", append=False):
         """Open or append a new image via the Lattice Expression Language (LEL) interface.
 
         Parameters
@@ -405,16 +405,16 @@ class Session:
         expression : {0}
             The LEL arithmetic expression.
         directory : {1}
-            The directory to the image file(s), either relative to the session's current directory or an absolute path relative to the CARTA backend's root directory.
+            The base directory for the LEL expression, either relative to the session's current directory or an absolute path relative to the CARTA backend's root directory. Defaults to the session's current directory.
         hdu : {2}
             The HDU to select inside the file.
         append : {3}
             Whether the image should be appended. Default is ``False``.
         """
-        file_name = expression
-        if "/" in expression:
+        if directory is None:
             directory = self.pwd()
-        return Image.new(self, directory, file_name, hdu, append, True)
+        directory = self.resolve_file_path(directory)
+        return Image.new(self, directory, expression, hdu, append, True)
 
     def image_list(self):
         """Return the list of currently open images.

--- a/carta/session.py
+++ b/carta/session.py
@@ -10,7 +10,7 @@ import base64
 import posixpath
 
 from .image import Image
-from .constants import CoordinateSystem, LabelType, BeamType, PaletteColor, Overlay, PanelMode, GridMode, ComplexExpression, NumberFormat
+from .constants import CoordinateSystem, LabelType, BeamType, PaletteColor, Overlay, PanelMode, GridMode, ComplexComponent, NumberFormat
 from .backend import Backend
 from .protocol import Protocol
 from .util import logger, Macro, split_action_path, CartaBadID, CartaBadSession, CartaBadUrl
@@ -360,8 +360,8 @@ class Session:
         directory, file_name = posixpath.split(path)
         return Image.new(self, directory, file_name, hdu, append, False, make_active=make_active, update_directory=update_directory)
 
-    @validate(String(), Constant(ComplexExpression), Boolean(), Boolean(), Boolean())
-    def open_complex_image(self, path, expression=ComplexExpression.AMPLITUDE, append=False, make_active=True, update_directory=False):
+    @validate(String(), Constant(ComplexComponent), Boolean(), Boolean(), Boolean())
+    def open_complex_image(self, path, expression=ComplexComponent.AMPLITUDE, append=False, make_active=True, update_directory=False):
         """Open or append a new complex-valued image.
 
         Parameters
@@ -369,7 +369,7 @@ class Session:
         path : {0}
             The path to the complex-valued image file, either relative to the session's current directory or an absolute path relative to the CARTA backend's root directory.
         expression : {1}
-            The complex expression to use when opening the image. The default is :obj:`carta.constants.ComplexExpression.AMPLITUDE`.
+            The complex component to use when opening the image. The default is :obj:`carta.constants.ComplexComponent.AMPLITUDE`.
         append : {2}
             Whether the image should be appended to existing images. By default this is ``False`` and any existing open images are closed.
         make_active : {3}

--- a/carta/session.py
+++ b/carta/session.py
@@ -392,6 +392,9 @@ class Session:
         """
         return Image.new(self, path, hdu, True, complex, expression)
 
+    def load_LEL_image(self, directory, expression, hdu="", complex=False):
+        return Image.new(self, directory, hdu, False, complex, expression)
+
     def image_list(self):
         """Return the list of currently open images.
 

--- a/carta/session.py
+++ b/carta/session.py
@@ -375,7 +375,7 @@ class Session:
         path = self.resolve_file_path(path)
         directory, file_name = posixpath.split(path)
         return Image.new(self, directory, file_name, hdu, append, False)
-    
+
     @validate(String(), String(r"\d*"), Constant(ComplexExpression), Boolean())
     def open_complex_image(self, path, expression=ComplexExpression.AMPLITUDE, hdu="", append=False):
         """Open or append a new complex-valued image.
@@ -414,7 +414,6 @@ class Session:
         file_name = expression
         if "/" in expression:
             directory = self.pwd()
-        directory = self.resolve_file_path(directory)
         return Image.new(self, directory, file_name, hdu, append, True)
 
     def image_list(self):

--- a/carta/session.py
+++ b/carta/session.py
@@ -385,7 +385,7 @@ class Session:
         path : {0}
             The path to the complex-valued image file, either relative to the session's current directory or an absolute path relative to the CARTA backend's root directory.
         expression : {1}
-            The complex expression for opening a complex-valued image. The default is :obj:`carta.constants.ComplexExpression.AMPLITUDE`.
+            The complex expression to use when opening the image. The default is :obj:`carta.constants.ComplexExpression.AMPLITUDE`.
         append : {2}
             Whether the image should be appended to existing images. By default this is ``False`` and any existing open images are closed.
         """

--- a/carta/session.py
+++ b/carta/session.py
@@ -355,10 +355,12 @@ class Session:
         update_directory : {3}
             Whether the starting directory of the frontend file browser should be updated to the parent directory of the image. The default is ``False``.
         """
-        return Image.new(self, path, hdu, append, False, False, "", update_directory=update_directory)
+        path = self.resolve_file_path(path)
+        directory, file_name = posixpath.split(path)
+        return Image.new(self, directory, file_name, hdu, append, False, update_directory=update_directory)
 
-    @validate(String(), Constant(ComplexExpression), String(r"\d*"), Boolean(), Boolean())
-    def open_complex_image(self, path, expression=ComplexExpression.AMPLITUDE, hdu="", append=False, update_directory=False):
+    @validate(String(), Constant(ComplexExpression), Boolean(), Boolean(), Boolean())
+    def open_complex_image(self, path, expression=ComplexExpression.AMPLITUDE, append=False, update_directory=False):
         """Open or append a new complex-valued image.
 
         Parameters
@@ -367,33 +369,33 @@ class Session:
             The path to the complex-valued image file, either relative to the session's current directory or an absolute path relative to the CARTA backend's root directory.
         expression : {1}
             The complex expression to use when opening the image. The default is :obj:`carta.constants.ComplexExpression.AMPLITUDE`.
-        hdu : {2}
-            The HDU to select inside the file.
-        append : {3}
+        append : {2}
             Whether the image should be appended to existing images. By default this is ``False`` and any existing open images are closed.
-        update_directory : {4}
+        update_directory : {3}
             Whether the starting directory of the frontend file browser should be updated to the parent directory of the image. The default is ``False``.
         """
-        return Image.new(self, path, hdu, append, True, True, expression, update_directory=update_directory)
+        path = self.resolve_file_path(path)
+        directory, file_name = posixpath.split(path)
+        expression = f'{expression}("{file_name}")'
+        return Image.new(self, directory, expression, "", append, True, update_directory=update_directory)
 
-    @validate(String(), String(), String(), Boolean(), Boolean())
-    def open_LEL_image(self, expression, path=".", hdu="", append=False, update_directory=False):
+    @validate(String(), String(), Boolean(), Boolean(), Boolean())
+    def open_LEL_image(self, expression, directory=".", append=False, update_directory=False):
         """Open or append a new image via the Lattice Expression Language (LEL) interface.
 
         Parameters
         ----------
         expression : {0}
             The LEL arithmetic expression.
-        path : {1}
-            The base path for the LEL expression, either relative to the session's current directory or an absolute path relative to the CARTA backend's root directory. Defaults to the session's current directory.
-        hdu : {2}
-            The HDU to select inside the file.
-        append : {3}
+        directory : {1}
+            The base directory for the LEL expression, either relative to the session's current directory or an absolute path relative to the CARTA backend's root directory. Defaults to the session's current directory.
+        append : {2}
             Whether the image should be appended to existing images. By default this is ``False`` and any existing open images are closed.
-        update_directory : {4}
+        update_directory : {3}
             Whether the starting directory of the frontend file browser should be updated to the parent directory of the image. The default is ``False``.
         """
-        return Image.new(self, path, hdu, append, False, True, expression, update_directory=update_directory)
+        directory = self.resolve_file_path(directory)
+        return Image.new(self, directory, expression, "", append, True, update_directory=update_directory)
 
     def image_list(self):
         """Return the list of currently open images.

--- a/carta/session.py
+++ b/carta/session.py
@@ -9,7 +9,7 @@ Alternatively, the user can create a new session which runs in a headless browse
 import base64
 
 from .image import Image
-from .constants import CoordinateSystem, LabelType, BeamType, PaletteColor, Overlay, PanelMode, GridMode, ArithmeticExpression
+from .constants import CoordinateSystem, LabelType, BeamType, PaletteColor, Overlay, PanelMode, GridMode, ComplexExpression
 from .backend import Backend
 from .protocol import Protocol
 from .util import logger, Macro, split_action_path, CartaBadID, CartaBadSession, CartaBadUrl
@@ -358,8 +358,8 @@ class Session:
 
     # IMAGES
 
-    @validate(String(), String(r"\d*"), Boolean(), Constant(ArithmeticExpression))
-    def open_image(self, path, hdu="", complex=False, expression=ArithmeticExpression.AMPLITUDE):
+    @validate(String(), String(r"\d*"), Boolean(), Constant(ComplexExpression))
+    def open_image(self, path, hdu="", complex=False, expression=ComplexExpression.AMPLITUDE):
         """Open a new image, replacing any existing images.
 
         Parameters
@@ -371,12 +371,12 @@ class Session:
         complex : {2}
             Whether the image is complex. Set to ``False`` by default.
         expression : {3}
-            Arithmetic expression to use if opening a complex-valued image. The default is :obj:`carta.constants.ArithmeticExpression.AMPLITUDE`.
+            Complex expression to use if opening a complex-valued image. The default is :obj:`carta.constants.ComplexExpression.AMPLITUDE`.
         """
         return Image.new(self, path, hdu, False, complex, expression)
 
-    @validate(String(), String(r"\d*"), Boolean(), Constant(ArithmeticExpression))
-    def append_image(self, path, hdu="", complex=False, expression=ArithmeticExpression.AMPLITUDE):
+    @validate(String(), String(r"\d*"), Boolean(), Constant(ComplexExpression))
+    def append_image(self, path, hdu="", complex=False, expression=ComplexExpression.AMPLITUDE):
         """Append a new image, keeping any existing images.
 
         Parameters
@@ -388,12 +388,27 @@ class Session:
         complex : {2}
             Whether the image is complex. Set to ``False`` by default.
         expression : {3}
-            Arithmetic expression to use if appending a complex-valued image. The default is :obj:`carta.constants.ArithmeticExpression.AMPLITUDE`.
+            Complex expression to use if appending a complex-valued image. The default is :obj:`carta.constants.ComplexExpression.AMPLITUDE`.
         """
         return Image.new(self, path, hdu, True, complex, expression)
 
-    def load_LEL_image(self, directory, expression, hdu="", complex=False):
-        return Image.new(self, directory, hdu, False, complex, expression)
+    @validate(String(), String(), String(r"\d*"), Boolean())
+    def load_LEL_image(self, directory, expression, hdu="", append=False):
+        """Open or append a new image via the Lattice Expression Language (LEL) interface.
+
+        Parameters
+        ----------
+        directory : {0}
+            The directory of the image file(s), either relative to the session's current directory or an absolute path relative to the CARTA backend's root directory.
+        expression : {1}
+            The LEL arithmetic expression.
+        hdu : {2}
+            The HDU to select inside the file.
+        append : {3}
+            Whether the image should be appended. Default is ``False``.
+        """
+        complex = False
+        return Image.new(self, directory, hdu, append, complex, expression)
 
     def image_list(self):
         """Return the list of currently open images.

--- a/carta/session.py
+++ b/carta/session.py
@@ -396,7 +396,7 @@ class Session:
         make_active : {3}
             Whether the image should be made active in the frontend. This only applies if an image is being appended. The default is ``True``.
         update_directory : {4}
-            Whether the starting directory of the frontend file browser should be updated to the parent directory of the image. The default is ``False``.
+            Whether the starting directory of the frontend file browser should be updated to the base directory of the LEL expression. The default is ``False``.
         """
         return Image.new(self, directory, expression, "", append, True, make_active=make_active, update_directory=update_directory)
 

--- a/carta/session.py
+++ b/carta/session.py
@@ -378,8 +378,8 @@ class Session:
             Whether the starting directory of the frontend file browser should be updated to the parent directory of the image. The default is ``False``.
         """
         directory, file_name = posixpath.split(path)
-        component = f'{component}("{file_name}")'
-        return Image.new(self, directory, component, "", append, True, make_active=make_active, update_directory=update_directory)
+        expression = f'{component}("{file_name}")'
+        return Image.new(self, directory, expression, "", append, True, make_active=make_active, update_directory=update_directory)
 
     @validate(String(), String(), Boolean(), Boolean(), Boolean())
     def open_LEL_image(self, expression, directory=".", append=False, make_active=True, update_directory=False):

--- a/carta/session.py
+++ b/carta/session.py
@@ -376,8 +376,8 @@ class Session:
         directory, file_name = posixpath.split(path)
         return Image.new(self, directory, file_name, hdu, append, False)
 
-    @validate(String(), String(r"\d*"), Constant(ComplexExpression), Boolean())
-    def open_complex_image(self, path, expression=ComplexExpression.AMPLITUDE, hdu="", append=False):
+    @validate(String(), Constant(ComplexExpression), Boolean())
+    def open_complex_image(self, path, expression=ComplexExpression.AMPLITUDE, append=False):
         """Open or append a new complex-valued image.
 
         Parameters
@@ -386,18 +386,16 @@ class Session:
             The path to the complex-valued image file, either relative to the session's current directory or an absolute path relative to the CARTA backend's root directory.
         expression : {1}
             The complex expression for opening a complex-valued image.
-        hdu : {2}
-            The HDU to select inside the file.
-        append : {3}
+        append : {2}
             Whether the image should be appended. Default is ``False``.
         """
         path = self.resolve_file_path(path)
         directory, file_name = posixpath.split(path)
         expression = f'{expression}("{file_name}")'
-        return Image.new(self, directory, expression, hdu, append, True)
+        return Image.new(self, directory, expression, "", append, True)
 
-    @validate(String(), String(), String(r"\d*"), Boolean())
-    def open_LEL_image(self, expression, directory=None, hdu="", append=False):
+    @validate(String(), String(), Boolean())
+    def open_LEL_image(self, expression, directory=None, append=False):
         """Open or append a new image via the Lattice Expression Language (LEL) interface.
 
         Parameters
@@ -406,15 +404,13 @@ class Session:
             The LEL arithmetic expression.
         directory : {1}
             The base directory for the LEL expression, either relative to the session's current directory or an absolute path relative to the CARTA backend's root directory. Defaults to the session's current directory.
-        hdu : {2}
-            The HDU to select inside the file.
-        append : {3}
+        append : {2}
             Whether the image should be appended. Default is ``False``.
         """
         if directory is None:
             directory = self.pwd()
         directory = self.resolve_file_path(directory)
-        return Image.new(self, directory, expression, hdu, append, True)
+        return Image.new(self, directory, expression, "", append, True)
 
     def image_list(self):
         """Return the list of currently open images.

--- a/carta/session.py
+++ b/carta/session.py
@@ -340,8 +340,8 @@ class Session:
 
     # IMAGES
 
-    @validate(String(), String(r"\d*"), Boolean(), Boolean())
-    def open_image(self, path, hdu="", append=False, update_directory=False):
+    @validate(String(), String(r"\d*"), Boolean(), Boolean(), Boolean())
+    def open_image(self, path, hdu="", append=False, make_active=True, update_directory=False):
         """Open or append a new image.
 
         Parameters
@@ -352,14 +352,16 @@ class Session:
             The HDU to select inside the file.
         append : {2}
             Whether the image should be appended to existing images. By default this is ``False`` and any existing open images are closed.
-        update_directory : {3}
+        make_active : {3}
+            Whether the image should be made active in the frontend. This only applies if an image is being appended. The default is ``True``.
+        update_directory : {4}
             Whether the starting directory of the frontend file browser should be updated to the parent directory of the image. The default is ``False``.
         """
         directory, file_name = posixpath.split(path)
-        return Image.new(self, directory, file_name, hdu, append, False, update_directory=update_directory)
+        return Image.new(self, directory, file_name, hdu, append, False, make_active=make_active, update_directory=update_directory)
 
     @validate(String(), Constant(ComplexExpression), Boolean(), Boolean(), Boolean())
-    def open_complex_image(self, path, expression=ComplexExpression.AMPLITUDE, append=False, update_directory=False):
+    def open_complex_image(self, path, expression=ComplexExpression.AMPLITUDE, append=False, make_active=True, update_directory=False):
         """Open or append a new complex-valued image.
 
         Parameters
@@ -370,15 +372,17 @@ class Session:
             The complex expression to use when opening the image. The default is :obj:`carta.constants.ComplexExpression.AMPLITUDE`.
         append : {2}
             Whether the image should be appended to existing images. By default this is ``False`` and any existing open images are closed.
-        update_directory : {3}
+        make_active : {3}
+            Whether the image should be made active in the frontend. This only applies if an image is being appended. The default is ``True``.
+        update_directory : {4}
             Whether the starting directory of the frontend file browser should be updated to the parent directory of the image. The default is ``False``.
         """
         directory, file_name = posixpath.split(path)
         expression = f'{expression}("{file_name}")'
-        return Image.new(self, directory, expression, "", append, True, update_directory=update_directory)
+        return Image.new(self, directory, expression, "", append, True, make_active=make_active, update_directory=update_directory)
 
     @validate(String(), String(), Boolean(), Boolean(), Boolean())
-    def open_LEL_image(self, expression, directory=".", append=False, update_directory=False):
+    def open_LEL_image(self, expression, directory=".", append=False, make_active=True, update_directory=False):
         """Open or append a new image via the Lattice Expression Language (LEL) interface.
 
         Parameters
@@ -389,10 +393,12 @@ class Session:
             The base directory for the LEL expression, either relative to the session's current directory or an absolute path relative to the CARTA backend's root directory. Defaults to the session's current directory.
         append : {2}
             Whether the image should be appended to existing images. By default this is ``False`` and any existing open images are closed.
-        update_directory : {3}
+        make_active : {3}
+            Whether the image should be made active in the frontend. This only applies if an image is being appended. The default is ``True``.
+        update_directory : {4}
             Whether the starting directory of the frontend file browser should be updated to the parent directory of the image. The default is ``False``.
         """
-        return Image.new(self, directory, expression, "", append, True, update_directory=update_directory)
+        return Image.new(self, directory, expression, "", append, True, make_active=make_active, update_directory=update_directory)
 
     def image_list(self):
         """Return the list of currently open images.

--- a/carta/session.py
+++ b/carta/session.py
@@ -355,12 +355,10 @@ class Session:
         update_directory : {3}
             Whether the starting directory of the frontend file browser should be updated to the parent directory of the image. The default is ``False``.
         """
-        path = self.resolve_file_path(path)
-        directory, file_name = posixpath.split(path)
-        return Image.new(self, directory, file_name, hdu, append, False, update_directory=update_directory)
+        return Image.new(self, path, hdu, append, False, False, "", update_directory=update_directory)
 
-    @validate(String(), Constant(ComplexExpression), Boolean(), Boolean(), Boolean())
-    def open_complex_image(self, path, expression=ComplexExpression.AMPLITUDE, append=False, update_directory=False):
+    @validate(String(), Constant(ComplexExpression), String(r"\d*"), Boolean(), Boolean())
+    def open_complex_image(self, path, expression=ComplexExpression.AMPLITUDE, hdu="", append=False, update_directory=False):
         """Open or append a new complex-valued image.
 
         Parameters
@@ -369,33 +367,33 @@ class Session:
             The path to the complex-valued image file, either relative to the session's current directory or an absolute path relative to the CARTA backend's root directory.
         expression : {1}
             The complex expression to use when opening the image. The default is :obj:`carta.constants.ComplexExpression.AMPLITUDE`.
-        append : {2}
+        hdu : {2}
+            The HDU to select inside the file.
+        append : {3}
             Whether the image should be appended to existing images. By default this is ``False`` and any existing open images are closed.
-        update_directory : {3}
+        update_directory : {4}
             Whether the starting directory of the frontend file browser should be updated to the parent directory of the image. The default is ``False``.
         """
-        path = self.resolve_file_path(path)
-        directory, file_name = posixpath.split(path)
-        expression = f'{expression}("{file_name}")'
-        return Image.new(self, directory, expression, "", append, True, update_directory=update_directory)
+        return Image.new(self, path, hdu, append, True, True, expression, update_directory=update_directory)
 
-    @validate(String(), String(), Boolean(), Boolean(), Boolean())
-    def open_LEL_image(self, expression, directory=".", append=False, update_directory=False):
+    @validate(String(), String(), String(), Boolean(), Boolean())
+    def open_LEL_image(self, expression, path=".", hdu="", append=False, update_directory=False):
         """Open or append a new image via the Lattice Expression Language (LEL) interface.
 
         Parameters
         ----------
         expression : {0}
             The LEL arithmetic expression.
-        directory : {1}
-            The base directory for the LEL expression, either relative to the session's current directory or an absolute path relative to the CARTA backend's root directory. Defaults to the session's current directory.
-        append : {2}
+        path : {1}
+            The base path for the LEL expression, either relative to the session's current directory or an absolute path relative to the CARTA backend's root directory. Defaults to the session's current directory.
+        hdu : {2}
+            The HDU to select inside the file.
+        append : {3}
             Whether the image should be appended to existing images. By default this is ``False`` and any existing open images are closed.
-        update_directory : {3}
+        update_directory : {4}
             Whether the starting directory of the frontend file browser should be updated to the parent directory of the image. The default is ``False``.
         """
-        directory = self.resolve_file_path(directory)
-        return Image.new(self, directory, expression, "", append, True, update_directory=update_directory)
+        return Image.new(self, path, hdu, append, False, True, expression, update_directory=update_directory)
 
     def image_list(self):
         """Return the list of currently open images.

--- a/carta/session.py
+++ b/carta/session.py
@@ -361,15 +361,15 @@ class Session:
         return Image.new(self, directory, file_name, hdu, append, False, make_active=make_active, update_directory=update_directory)
 
     @validate(String(), Constant(ComplexComponent), Boolean(), Boolean(), Boolean())
-    def open_complex_image(self, path, expression=ComplexComponent.AMPLITUDE, append=False, make_active=True, update_directory=False):
+    def open_complex_image(self, path, component=ComplexComponent.AMPLITUDE, append=False, make_active=True, update_directory=False):
         """Open or append a new complex-valued image.
 
         Parameters
         ----------
         path : {0}
             The path to the complex-valued image file, either relative to the session's current directory or an absolute path relative to the CARTA backend's root directory.
-        expression : {1}
-            The complex component to use when opening the image. The default is :obj:`carta.constants.ComplexComponent.AMPLITUDE`.
+        component : {1}
+            The complex component to select when opening the image. The default is :obj:`carta.constants.ComplexComponent.AMPLITUDE`.
         append : {2}
             Whether the image should be appended to existing images. By default this is ``False`` and any existing open images are closed.
         make_active : {3}
@@ -378,8 +378,8 @@ class Session:
             Whether the starting directory of the frontend file browser should be updated to the parent directory of the image. The default is ``False``.
         """
         directory, file_name = posixpath.split(path)
-        expression = f'{expression}("{file_name}")'
-        return Image.new(self, directory, expression, "", append, True, make_active=make_active, update_directory=update_directory)
+        component = f'{component}("{file_name}")'
+        return Image.new(self, directory, component, "", append, True, make_active=make_active, update_directory=update_directory)
 
     @validate(String(), String(), Boolean(), Boolean(), Boolean())
     def open_LEL_image(self, expression, directory=".", append=False, make_active=True, update_directory=False):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="carta",
-    version="1.1.9",
+    version="1.1.10",
     author="Adrianna Pińska",
     author_email="adrianna.pinska@gmail.com",
     description="CARTA scripting wrapper written in Python",

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -4,7 +4,7 @@ import pytest
 from carta.session import Session
 from carta.image import Image
 from carta.util import CartaValidationFailed
-from carta.constants import NumberFormat as NF, CoordinateSystem, SpatialAxis as SA, ComplexExpression as CE
+from carta.constants import NumberFormat as NF, CoordinateSystem, SpatialAxis as SA, ArithmeticExpression as AE
 
 # FIXTURES
 
@@ -101,22 +101,22 @@ def test_image_properties_have_docstrings(member):
 
 @pytest.mark.parametrize("args,kwargs,expected_params", [
     # Open a plain image
-    (["subdir/image.fits", "", False, False, False, None], {},
+    (["subdir/image.fits", "", False, False, None], {},
      ["openFile", "/my_data/subdir", "image.fits", "", False, False]),
     # Open a complex image
-    (["subdir/image.fits", "", False, True, True, CE.AMPLITUDE], {},
+    (["subdir/image.fits", "", False, True, AE.AMPLITUDE], {},
      ["openFile", "/my_data/subdir", 'AMPLITUDE("image.fits")', "", True, False]),
     # Append a plain image
-    (["subdir/image.fits", "", True, False, False, None], {},
+    (["subdir/image.fits", "", True, False, None], {},
      ["appendFile", "/my_data/subdir", "image.fits", "", False, True, False]),
     # Append a complex image
-    (["subdir/image.fits", "", True, True, True, CE.AMPLITUDE], {},
+    (["subdir/image.fits", "", True, True, AE.AMPLITUDE], {},
      ["appendFile", "/my_data/subdir", 'AMPLITUDE("image.fits")', "", True, True, False]),
     # Open a plain image; update the file browser directory
-    (["subdir/image.fits", "", False, False, False, None], {"update_directory": True},
+    (["subdir/image.fits", "", False, False, None], {"update_directory": True},
      ["openFile", "/my_data/subdir", "image.fits", "", False, True]),
     # Append a plain image; don't set it to active
-    (["subdir/image.fits", "", True, False, False, None], {"make_active": False},
+    (["subdir/image.fits", "", True, False, None], {"make_active": False},
      ["appendFile", "/my_data/subdir", "image.fits", "", False, False, False]),
 ])
 def test_new(session, mock_session_call_action, mock_session_method, args, kwargs, expected_params):

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -4,7 +4,7 @@ import pytest
 from carta.session import Session
 from carta.image import Image
 from carta.util import CartaValidationFailed
-from carta.constants import NumberFormat as NF, CoordinateSystem, SpatialAxis as SA, ComplexExpression as CE
+from carta.constants import NumberFormat as NF, CoordinateSystem, SpatialAxis as SA
 
 # FIXTURES
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -106,15 +106,9 @@ def test_image_properties_have_docstrings(member):
     # Open a complex image
     (["subdir", 'AMPLITUDE("image.fits")', "", False, True], {},
      ["openFile", "/my_data/subdir", 'AMPLITUDE("image.fits")', "", True, False]),
-    # Open a LEL image
-    (["subdir", "2*image.fits", "", False, True], {},
-     ["openFile", "/my_data/subdir", "2*image.fits", "", True, False]),
     # Append a plain image
     (["subdir", "image.fits", "", True, False], {},
      ["appendFile", "/my_data/subdir", "image.fits", "", False, True, False]),
-    # Append a complex image
-    (["subdir", 'AMPLITUDE("image.fits")', "", True, True], {},
-     ["appendFile", "/my_data/subdir", 'AMPLITUDE("image.fits")', "", True, True, False]),
     # Append a LEL image
     (["subdir", "2*image.fits", "", True, True], {},
      ["appendFile", "/my_data/subdir", "2*image.fits", "", True, True, False]),

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -103,13 +103,13 @@ def test_image_properties_have_docstrings(member):
     # Open a plain image
     (["subdir", "image.fits", "", False, False], {},
      ["openFile", "/my_data/subdir", "image.fits", "", False, False]),
-    # Open a complex image
-    (["subdir", 'AMPLITUDE("image.fits")', "", False, True], {},
-     ["openFile", "/my_data/subdir", 'AMPLITUDE("image.fits")', "", True, False]),
+    # Open an expression
+    (["subdir", '2*image.fits', "", False, True], {},
+     ["openFile", "/my_data/subdir", '2*image.fits', "", True, False]),
     # Append a plain image
     (["subdir", "image.fits", "", True, False], {},
      ["appendFile", "/my_data/subdir", "image.fits", "", False, True, False]),
-    # Append a LEL image
+    # Append an expression
     (["subdir", "2*image.fits", "", True, True], {},
      ["appendFile", "/my_data/subdir", "2*image.fits", "", True, True, False]),
     # Open a plain image; update the file browser directory

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -4,7 +4,7 @@ import pytest
 from carta.session import Session
 from carta.image import Image
 from carta.util import CartaValidationFailed
-from carta.constants import NumberFormat as NF, CoordinateSystem, SpatialAxis as SA, ArithmeticExpression as AE
+from carta.constants import NumberFormat as NF, CoordinateSystem, SpatialAxis as SA, ComplexExpression as CE
 
 # FIXTURES
 
@@ -101,22 +101,28 @@ def test_image_properties_have_docstrings(member):
 
 @pytest.mark.parametrize("args,kwargs,expected_params", [
     # Open a plain image
-    (["subdir/image.fits", "", False, False, None], {},
+    (["subdir", "image.fits", "", False, False], {},
      ["openFile", "/my_data/subdir", "image.fits", "", False, False]),
     # Open a complex image
-    (["subdir/image.fits", "", False, True, AE.AMPLITUDE], {},
+    (["subdir", 'AMPLITUDE("image.fits")', "", False, True], {},
      ["openFile", "/my_data/subdir", 'AMPLITUDE("image.fits")', "", True, False]),
+    # Open a LEL image
+    (["subdir", "2*image.fits", "", False, True], {},
+     ["openFile", "/my_data/subdir", "2*image.fits", "", True, False]),
     # Append a plain image
-    (["subdir/image.fits", "", True, False, None], {},
+    (["subdir", "image.fits", "", True, False], {},
      ["appendFile", "/my_data/subdir", "image.fits", "", False, True, False]),
     # Append a complex image
-    (["subdir/image.fits", "", True, True, AE.AMPLITUDE], {},
+    (["subdir", 'AMPLITUDE("image.fits")', "", True, True], {},
      ["appendFile", "/my_data/subdir", 'AMPLITUDE("image.fits")', "", True, True, False]),
+    # Append a LEL image
+    (["subdir", "2*image.fits", "", True, True], {},
+     ["appendFile", "/my_data/subdir", "2*image.fits", "", True, True, False]),
     # Open a plain image; update the file browser directory
-    (["subdir/image.fits", "", False, False, None], {"update_directory": True},
+    (["subdir", "image.fits", "", False, False], {"update_directory": True},
      ["openFile", "/my_data/subdir", "image.fits", "", False, True]),
     # Append a plain image; don't set it to active
-    (["subdir/image.fits", "", True, False, None], {"make_active": False},
+    (["subdir", "image.fits", "", True, False], {"make_active": False},
      ["appendFile", "/my_data/subdir", "image.fits", "", False, False, False]),
 ])
 def test_new(session, mock_session_call_action, mock_session_method, args, kwargs, expected_params):

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -4,7 +4,7 @@ import pytest
 from carta.session import Session
 from carta.image import Image
 from carta.util import CartaValidationFailed
-from carta.constants import NumberFormat as NF, CoordinateSystem, SpatialAxis as SA, ArithmeticExpression as AE
+from carta.constants import NumberFormat as NF, CoordinateSystem, SpatialAxis as SA, ComplexExpression as CE
 
 # FIXTURES
 
@@ -101,22 +101,22 @@ def test_image_properties_have_docstrings(member):
 
 @pytest.mark.parametrize("args,kwargs,expected_params", [
     # Open a plain image
-    (["subdir/image.fits", "", False, False, None], {},
+    (["subdir/image.fits", "", False, False, False, None], {},
      ["openFile", "/my_data/subdir", "image.fits", "", False, False]),
     # Open a complex image
-    (["subdir/image.fits", "", False, True, AE.AMPLITUDE], {},
+    (["subdir/image.fits", "", False, True, True, CE.AMPLITUDE], {},
      ["openFile", "/my_data/subdir", 'AMPLITUDE("image.fits")', "", True, False]),
     # Append a plain image
-    (["subdir/image.fits", "", True, False, None], {},
+    (["subdir/image.fits", "", True, False, False, None], {},
      ["appendFile", "/my_data/subdir", "image.fits", "", False, True, False]),
     # Append a complex image
-    (["subdir/image.fits", "", True, True, AE.AMPLITUDE], {},
+    (["subdir/image.fits", "", True, True, True, CE.AMPLITUDE], {},
      ["appendFile", "/my_data/subdir", 'AMPLITUDE("image.fits")', "", True, True, False]),
     # Open a plain image; update the file browser directory
-    (["subdir/image.fits", "", False, False, None], {"update_directory": True},
+    (["subdir/image.fits", "", False, False, False, None], {"update_directory": True},
      ["openFile", "/my_data/subdir", "image.fits", "", False, True]),
     # Append a plain image; don't set it to active
-    (["subdir/image.fits", "", True, False, None], {"make_active": False},
+    (["subdir/image.fits", "", True, False, False, None], {"make_active": False},
      ["appendFile", "/my_data/subdir", "image.fits", "", False, False, False]),
 ])
 def test_new(session, mock_session_call_action, mock_session_method, args, kwargs, expected_params):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -4,7 +4,7 @@ import pytest
 from carta.session import Session
 from carta.image import Image
 from carta.util import CartaValidationFailed, Macro
-from carta.constants import CoordinateSystem, NumberFormat as NF, ComplexExpression as CE
+from carta.constants import CoordinateSystem, NumberFormat as NF, ArithmeticExpression as AE
 
 # FIXTURES
 
@@ -115,16 +115,16 @@ def test_cd(session, mock_method, mock_call_action):
 @pytest.mark.parametrize("args,kwargs,expected_args,expected_kwargs", [
     # Open plain image
     (["subdir/image.fits"], {},
-     ["subdir/image.fits", "", False, False, False, ""], {"update_directory": False}),
-    # Append plain image
-    (["subdir/image.fits"], {},
-     ["subdir/image.fits", "", True, False, False, ""], {"update_directory": False}),
+     ["subdir/image.fits", "", False, False, AE.AMPLITUDE], {"update_directory": False}),
     # Open plain image; select different HDU
     (["subdir/image.fits"], {"hdu": "3"},
-     ["subdir/image.fits", "3", False, False, False, ""], {"update_directory": False}),
+     ["subdir/image.fits", "3", False, False, AE.AMPLITUDE], {"update_directory": False}),
+    # Open complex image
+    (["subdir/image.fits"], {"complex": True},
+     ["subdir/image.fits", "", False, True, AE.AMPLITUDE], {"update_directory": False}),
     # Open plain image; update file browser directory
     (["subdir/image.fits"], {"update_directory": True},
-     ["subdir/image.fits", "", False, False, False, ""], {"update_directory": True}),
+     ["subdir/image.fits", "", False, False, AE.AMPLITUDE], {"update_directory": True}),
 ])
 def test_open_image(mocker, session, args, kwargs, expected_args, expected_kwargs):
     mock_image_new = mocker.patch.object(Image, "new")
@@ -132,6 +132,29 @@ def test_open_image(mocker, session, args, kwargs, expected_args, expected_kwarg
     mock_image_new.assert_called_with(session, *expected_args, **expected_kwargs)
 
 # TODO this should be merged with the test above when this separate function is removed
+
+
+@pytest.mark.parametrize("args,kwargs,expected_args,expected_kwargs", [
+    # Open plain image
+    (["subdir/image.fits"], {},
+     ["subdir/image.fits", "", True, False, AE.AMPLITUDE], {"make_active": True, "update_directory": False}),
+    # Open plain image; select different HDU
+    (["subdir/image.fits"], {"hdu": "3"},
+     ["subdir/image.fits", "3", True, False, AE.AMPLITUDE], {"make_active": True, "update_directory": False}),
+    # Open complex image
+    (["subdir/image.fits"], {"complex": True},
+     ["subdir/image.fits", "", True, True, AE.AMPLITUDE], {"make_active": True, "update_directory": False}),
+    # Open plain image; update file browser directory
+    (["subdir/image.fits"], {"update_directory": True},
+     ["subdir/image.fits", "", True, False, AE.AMPLITUDE], {"make_active": True, "update_directory": True}),
+    # Open plain image; don't make active
+    (["subdir/image.fits"], {"make_active": False},
+     ["subdir/image.fits", "", True, False, AE.AMPLITUDE], {"make_active": False, "update_directory": False}),
+])
+def test_append_image(mocker, session, args, kwargs, expected_args, expected_kwargs):
+    mock_image_new = mocker.patch.object(Image, "new")
+    session.append_image(*args, **kwargs)
+    mock_image_new.assert_called_with(session, *expected_args, **expected_kwargs)
 
 # OVERLAY
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -4,7 +4,7 @@ import pytest
 from carta.session import Session
 from carta.image import Image
 from carta.util import CartaValidationFailed, Macro
-from carta.constants import CoordinateSystem, NumberFormat as NF, ArithmeticExpression as AE
+from carta.constants import CoordinateSystem, NumberFormat as NF, ComplexExpression as CE
 
 # FIXTURES
 
@@ -115,16 +115,16 @@ def test_cd(session, mock_method, mock_call_action):
 @pytest.mark.parametrize("args,kwargs,expected_args,expected_kwargs", [
     # Open plain image
     (["subdir/image.fits"], {},
-     ["subdir/image.fits", "", False, False, AE.AMPLITUDE], {"update_directory": False}),
+     ["subdir/image.fits", "", False, False, CE.AMPLITUDE], {"update_directory": False}),
     # Open plain image; select different HDU
     (["subdir/image.fits"], {"hdu": "3"},
-     ["subdir/image.fits", "3", False, False, AE.AMPLITUDE], {"update_directory": False}),
+     ["subdir/image.fits", "3", False, False, CE.AMPLITUDE], {"update_directory": False}),
     # Open complex image
     (["subdir/image.fits"], {"complex": True},
-     ["subdir/image.fits", "", False, True, AE.AMPLITUDE], {"update_directory": False}),
+     ["subdir/image.fits", "", False, True, CE.AMPLITUDE], {"update_directory": False}),
     # Open plain image; update file browser directory
     (["subdir/image.fits"], {"update_directory": True},
-     ["subdir/image.fits", "", False, False, AE.AMPLITUDE], {"update_directory": True}),
+     ["subdir/image.fits", "", False, False, CE.AMPLITUDE], {"update_directory": True}),
 ])
 def test_open_image(mocker, session, args, kwargs, expected_args, expected_kwargs):
     mock_image_new = mocker.patch.object(Image, "new")
@@ -137,19 +137,19 @@ def test_open_image(mocker, session, args, kwargs, expected_args, expected_kwarg
 @pytest.mark.parametrize("args,kwargs,expected_args,expected_kwargs", [
     # Open plain image
     (["subdir/image.fits"], {},
-     ["subdir/image.fits", "", True, False, AE.AMPLITUDE], {"make_active": True, "update_directory": False}),
+     ["subdir/image.fits", "", True, False, CE.AMPLITUDE], {"make_active": True, "update_directory": False}),
     # Open plain image; select different HDU
     (["subdir/image.fits"], {"hdu": "3"},
-     ["subdir/image.fits", "3", True, False, AE.AMPLITUDE], {"make_active": True, "update_directory": False}),
+     ["subdir/image.fits", "3", True, False, CE.AMPLITUDE], {"make_active": True, "update_directory": False}),
     # Open complex image
     (["subdir/image.fits"], {"complex": True},
-     ["subdir/image.fits", "", True, True, AE.AMPLITUDE], {"make_active": True, "update_directory": False}),
+     ["subdir/image.fits", "", True, True, CE.AMPLITUDE], {"make_active": True, "update_directory": False}),
     # Open plain image; update file browser directory
     (["subdir/image.fits"], {"update_directory": True},
-     ["subdir/image.fits", "", True, False, AE.AMPLITUDE], {"make_active": True, "update_directory": True}),
+     ["subdir/image.fits", "", True, False, CE.AMPLITUDE], {"make_active": True, "update_directory": True}),
     # Open plain image; don't make active
     (["subdir/image.fits"], {"make_active": False},
-     ["subdir/image.fits", "", True, False, AE.AMPLITUDE], {"make_active": False, "update_directory": False}),
+     ["subdir/image.fits", "", True, False, CE.AMPLITUDE], {"make_active": False, "update_directory": False}),
 ])
 def test_append_image(mocker, session, args, kwargs, expected_args, expected_kwargs):
     mock_image_new = mocker.patch.object(Image, "new")

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -115,16 +115,16 @@ def test_cd(session, mock_method, mock_call_action):
 @pytest.mark.parametrize("args,kwargs,expected_args,expected_kwargs", [
     # Open plain image
     (["subdir/image.fits"], {},
-     ["subdir", "image.fits", "", False, False], {"update_directory": False}),
+     ["subdir", "image.fits", "", False, False], {"make_active": True, "update_directory": False}),
     # Append plain image
     (["subdir/image.fits"], {"append": True},
-     ["subdir", "image.fits", "", True, False], {"update_directory": False}),
+     ["subdir", "image.fits", "", True, False], {"make_active": True, "update_directory": False}),
     # Open plain image; select different HDU
     (["subdir/image.fits"], {"hdu": "3"},
-     ["subdir", "image.fits", "3", False, False], {"update_directory": False}),
+     ["subdir", "image.fits", "3", False, False], {"make_active": True, "update_directory": False}),
     # Open plain image; update file browser directory
     (["subdir/image.fits"], {"update_directory": True},
-     ["subdir", "image.fits", "", False, False], {"update_directory": True}),
+     ["subdir", "image.fits", "", False, False], {"make_active": True, "update_directory": True}),
 ])
 def test_open_image(mocker, session, args, kwargs, expected_args, expected_kwargs):
     mock_image_new = mocker.patch.object(Image, "new")
@@ -135,15 +135,18 @@ def test_open_image(mocker, session, args, kwargs, expected_args, expected_kwarg
 
 
 @pytest.mark.parametrize("args,kwargs,expected_args,expected_kwargs", [
-    # Open complex image (AMPLITUDE)
-    (["subdir/image.fits"], {"expression": CE.AMPLITUDE},
-     ["subdir", 'AMPLITUDE("image.fits")', "", False, True], {"update_directory": False}),
-    # Append complex image (PHASE)
-    (["subdir/image.fits"], {"expression": CE.PHASE, "append": True},
-     ["subdir", 'PHASE("image.fits")', "", True, True], {"update_directory": False}),
-    # Open complex image (REAL); update file browser directory
-    (["subdir/image.fits"], {"expression": CE.REAL, "update_directory": True},
-     ["subdir", 'REAL("image.fits")', "", False, True], {"update_directory": True}),
+    # Open complex image with default (AMPLITUDE) setting
+    (["subdir/image.fits"], {},
+     ["subdir", 'AMPLITUDE("image.fits")', "", False, True], {"make_active": True, "update_directory": False}),
+    # Open complex image (PHASE)
+    (["subdir/image.fits"], {"expression": CE.PHASE},
+     ["subdir", 'PHASE("image.fits")', "", False, True], {"make_active": True, "update_directory": False}),
+    # Append complex image (REAL)
+    (["subdir/image.fits"], {"expression": CE.REAL, "append": True},
+     ["subdir", 'REAL("image.fits")', "", True, True], {"make_active": True, "update_directory": False}),
+    # Open complex image (IMAG); update file browser directory
+    (["subdir/image.fits"], {"expression": CE.IMAG, "update_directory": True},
+     ["subdir", 'IMAG("image.fits")', "", False, True], {"make_active": True, "update_directory": True}),
 ])
 def test_open_complex_image(mocker, session, args, kwargs, expected_args, expected_kwargs):
     mock_image_new = mocker.patch.object(Image, "new")
@@ -154,13 +157,13 @@ def test_open_complex_image(mocker, session, args, kwargs, expected_args, expect
 @pytest.mark.parametrize("args,kwargs,expected_args,expected_kwargs", [
     # Open LEL image
     (["2*image.fits"], {},
-     [".", '2*image.fits', "", False, True], {"update_directory": False}),
+     [".", '2*image.fits', "", False, True], {"make_active": True, "update_directory": False}),
     # Append LEL image
     (["2*image.fits+image.fits"], {"append": True},
-     [".", '2*image.fits+image.fits', "", True, True], {"update_directory": False}),
+     [".", '2*image.fits+image.fits', "", True, True], {"make_active": True, "update_directory": False}),
     # Open LEL image; update file browser directory
     (["2*image.fits/image.fits"], {"update_directory": True},
-     [".", '2*image.fits/image.fits', "", False, True], {"update_directory": True}),
+     [".", '2*image.fits/image.fits', "", False, True], {"make_active": True, "update_directory": True}),
 ])
 def test_open_LEL_image(mocker, session, args, kwargs, expected_args, expected_kwargs):
     mock_image_new = mocker.patch.object(Image, "new")

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -119,6 +119,9 @@ def test_cd(session, mock_method, mock_call_action):
     # Append plain image
     (["subdir/image.fits"], {"append": True},
      ["subdir", "image.fits", "", True, False], {"make_active": True, "update_directory": False}),
+    # Append plain image; don't make active
+    (["subdir/image.fits"], {"append": True, "make_active": False},
+     ["subdir", "image.fits", "", True, False], {"make_active": False, "update_directory": False}),
     # Open plain image; select different HDU
     (["subdir/image.fits"], {"hdu": "3"},
      ["subdir", "image.fits", "3", False, False], {"make_active": True, "update_directory": False}),
@@ -135,16 +138,19 @@ def test_open_image(mocker, session, args, kwargs, expected_args, expected_kwarg
 
 
 @pytest.mark.parametrize("args,kwargs,expected_args,expected_kwargs", [
-    # Open complex image with default (AMPLITUDE) setting
+    # Open complex image with default component
     (["subdir/image.fits"], {},
      ["subdir", 'AMPLITUDE("image.fits")', "", False, True], {"make_active": True, "update_directory": False}),
-    # Open complex image (PHASE)
+    # Open complex image with component selected
     (["subdir/image.fits"], {"component": CC.PHASE},
      ["subdir", 'PHASE("image.fits")', "", False, True], {"make_active": True, "update_directory": False}),
-    # Append complex image (REAL)
+    # Append complex image
     (["subdir/image.fits"], {"component": CC.REAL, "append": True},
      ["subdir", 'REAL("image.fits")', "", True, True], {"make_active": True, "update_directory": False}),
-    # Open complex image (IMAG); update file browser directory
+    # Append complex image; don't make active
+    (["subdir/image.fits"], {"component": CC.REAL, "append": True, "make_active": False},
+     ["subdir", 'REAL("image.fits")', "", True, True], {"make_active": False, "update_directory": False}),
+    # Open complex image; update file browser directory
     (["subdir/image.fits"], {"component": CC.IMAG, "update_directory": True},
      ["subdir", 'IMAG("image.fits")', "", False, True], {"make_active": True, "update_directory": True}),
 ])
@@ -161,6 +167,9 @@ def test_open_complex_image(mocker, session, args, kwargs, expected_args, expect
     # Append LEL image
     (["2*image.fits+image.fits"], {"append": True},
      [".", '2*image.fits+image.fits', "", True, True], {"make_active": True, "update_directory": False}),
+    # Append LEL image; don't make active
+    (["2*image.fits+image.fits"], {"append": True, "make_active": False},
+     [".", '2*image.fits+image.fits', "", True, True], {"make_active": False, "update_directory": False}),
     # Open LEL image; update file browser directory
     (["2*image.fits/image.fits"], {"update_directory": True},
      [".", '2*image.fits/image.fits', "", False, True], {"make_active": True, "update_directory": True}),

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -139,13 +139,13 @@ def test_open_image(mocker, session, args, kwargs, expected_args, expected_kwarg
     (["subdir/image.fits"], {},
      ["subdir", 'AMPLITUDE("image.fits")', "", False, True], {"make_active": True, "update_directory": False}),
     # Open complex image (PHASE)
-    (["subdir/image.fits"], {"expression": CC.PHASE},
+    (["subdir/image.fits"], {"component": CC.PHASE},
      ["subdir", 'PHASE("image.fits")', "", False, True], {"make_active": True, "update_directory": False}),
     # Append complex image (REAL)
-    (["subdir/image.fits"], {"expression": CC.REAL, "append": True},
+    (["subdir/image.fits"], {"component": CC.REAL, "append": True},
      ["subdir", 'REAL("image.fits")', "", True, True], {"make_active": True, "update_directory": False}),
     # Open complex image (IMAG); update file browser directory
-    (["subdir/image.fits"], {"expression": CC.IMAG, "update_directory": True},
+    (["subdir/image.fits"], {"component": CC.IMAG, "update_directory": True},
      ["subdir", 'IMAG("image.fits")', "", False, True], {"make_active": True, "update_directory": True}),
 ])
 def test_open_complex_image(mocker, session, args, kwargs, expected_args, expected_kwargs):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -134,15 +134,39 @@ def test_open_image(mocker, session, args, kwargs, expected_args, expected_kwarg
 # TODO this should be merged with the test above when this separate function is removed
 
 
-# @pytest.mark.parametrize("args,kwargs,expected_args,expected_kwargs", [
-#     # Open complex image
-#     (["subdir/image.fits"], {"expression": CE.AMPLITUDE},
-#      ["subdir", 'AMPLITUDE("image.fits")', "", False, True], {"update_directory": False})
-# ])
-# def test_open_complex_image(mocker, session, args, kwargs, expected_args, expected_kwargs):
-#     mock_image_new = mocker.patch.object(Image, "new")
-#     session.open_image(*args, **kwargs)
-#     mock_image_new.assert_called_with(session, *expected_args, **expected_kwargs)
+@pytest.mark.parametrize("args,kwargs,expected_args,expected_kwargs", [
+    # Open complex image (AMPLITUDE)
+    (["subdir/image.fits"], {"expression": CE.AMPLITUDE},
+     ["subdir", 'AMPLITUDE("image.fits")', "", False, True], {"update_directory": False}),
+    # Append complex image (PHASE)
+    (["subdir/image.fits"], {"expression": CE.PHASE, "append": True},
+     ["subdir", 'PHASE("image.fits")', "", True, True], {"update_directory": False}),
+    # Open complex image (REAL); update file browser directory
+    (["subdir/image.fits"], {"expression": CE.REAL, "update_directory": True},
+     ["subdir", 'REAL("image.fits")', "", False, True], {"update_directory": True}),
+])
+def test_open_complex_image(mocker, session, args, kwargs, expected_args, expected_kwargs):
+    mock_image_new = mocker.patch.object(Image, "new")
+    session.open_complex_image(*args, **kwargs)
+    mock_image_new.assert_called_with(session, *expected_args, **expected_kwargs)
+
+
+@pytest.mark.parametrize("args,kwargs,expected_args,expected_kwargs", [
+    # Open LEL image
+    (["2*image.fits"], {},
+     [".", '2*image.fits', "", False, True], {"update_directory": False}),
+    # Append LEL image
+    (["2*image.fits+image.fits"], {"append": True},
+     [".", '2*image.fits+image.fits', "", True, True], {"update_directory": False}),
+    # Open LEL image; update file browser directory
+    (["2*image.fits/image.fits"], {"update_directory": True},
+     [".", '2*image.fits/image.fits', "", False, True], {"update_directory": True}),
+])
+def test_open_LEL_image(mocker, session, args, kwargs, expected_args, expected_kwargs):
+    mock_image_new = mocker.patch.object(Image, "new")
+    session.open_LEL_image(*args, **kwargs)
+    mock_image_new.assert_called_with(session, *expected_args, **expected_kwargs)
+
 
 # OVERLAY
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -4,7 +4,7 @@ import pytest
 from carta.session import Session
 from carta.image import Image
 from carta.util import CartaValidationFailed, Macro
-from carta.constants import CoordinateSystem, NumberFormat as NF, ComplexExpression as CE
+from carta.constants import CoordinateSystem, NumberFormat as NF, ComplexComponent as CC
 
 # FIXTURES
 
@@ -139,13 +139,13 @@ def test_open_image(mocker, session, args, kwargs, expected_args, expected_kwarg
     (["subdir/image.fits"], {},
      ["subdir", 'AMPLITUDE("image.fits")', "", False, True], {"make_active": True, "update_directory": False}),
     # Open complex image (PHASE)
-    (["subdir/image.fits"], {"expression": CE.PHASE},
+    (["subdir/image.fits"], {"expression": CC.PHASE},
      ["subdir", 'PHASE("image.fits")', "", False, True], {"make_active": True, "update_directory": False}),
     # Append complex image (REAL)
-    (["subdir/image.fits"], {"expression": CE.REAL, "append": True},
+    (["subdir/image.fits"], {"expression": CC.REAL, "append": True},
      ["subdir", 'REAL("image.fits")', "", True, True], {"make_active": True, "update_directory": False}),
     # Open complex image (IMAG); update file browser directory
-    (["subdir/image.fits"], {"expression": CE.IMAG, "update_directory": True},
+    (["subdir/image.fits"], {"expression": CC.IMAG, "update_directory": True},
      ["subdir", 'IMAG("image.fits")', "", False, True], {"make_active": True, "update_directory": True}),
 ])
 def test_open_complex_image(mocker, session, args, kwargs, expected_args, expected_kwargs):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -4,7 +4,7 @@ import pytest
 from carta.session import Session
 from carta.image import Image
 from carta.util import CartaValidationFailed, Macro
-from carta.constants import CoordinateSystem, NumberFormat as NF, ArithmeticExpression as AE
+from carta.constants import CoordinateSystem, NumberFormat as NF, ComplexExpression as CE
 
 # FIXTURES
 
@@ -115,16 +115,16 @@ def test_cd(session, mock_method, mock_call_action):
 @pytest.mark.parametrize("args,kwargs,expected_args,expected_kwargs", [
     # Open plain image
     (["subdir/image.fits"], {},
-     ["subdir/image.fits", "", False, False, AE.AMPLITUDE], {"update_directory": False}),
+     ["subdir/image.fits", "", False, False, False, ""], {"update_directory": False}),
+    # Append plain image
+    (["subdir/image.fits"], {},
+     ["subdir/image.fits", "", True, False, False, ""], {"update_directory": False}),
     # Open plain image; select different HDU
     (["subdir/image.fits"], {"hdu": "3"},
-     ["subdir/image.fits", "3", False, False, AE.AMPLITUDE], {"update_directory": False}),
-    # Open complex image
-    (["subdir/image.fits"], {"complex": True},
-     ["subdir/image.fits", "", False, True, AE.AMPLITUDE], {"update_directory": False}),
+     ["subdir/image.fits", "3", False, False, False, ""], {"update_directory": False}),
     # Open plain image; update file browser directory
     (["subdir/image.fits"], {"update_directory": True},
-     ["subdir/image.fits", "", False, False, AE.AMPLITUDE], {"update_directory": True}),
+     ["subdir/image.fits", "", False, False, False, ""], {"update_directory": True}),
 ])
 def test_open_image(mocker, session, args, kwargs, expected_args, expected_kwargs):
     mock_image_new = mocker.patch.object(Image, "new")
@@ -132,29 +132,6 @@ def test_open_image(mocker, session, args, kwargs, expected_args, expected_kwarg
     mock_image_new.assert_called_with(session, *expected_args, **expected_kwargs)
 
 # TODO this should be merged with the test above when this separate function is removed
-
-
-@pytest.mark.parametrize("args,kwargs,expected_args,expected_kwargs", [
-    # Open plain image
-    (["subdir/image.fits"], {},
-     ["subdir/image.fits", "", True, False, AE.AMPLITUDE], {"make_active": True, "update_directory": False}),
-    # Open plain image; select different HDU
-    (["subdir/image.fits"], {"hdu": "3"},
-     ["subdir/image.fits", "3", True, False, AE.AMPLITUDE], {"make_active": True, "update_directory": False}),
-    # Open complex image
-    (["subdir/image.fits"], {"complex": True},
-     ["subdir/image.fits", "", True, True, AE.AMPLITUDE], {"make_active": True, "update_directory": False}),
-    # Open plain image; update file browser directory
-    (["subdir/image.fits"], {"update_directory": True},
-     ["subdir/image.fits", "", True, False, AE.AMPLITUDE], {"make_active": True, "update_directory": True}),
-    # Open plain image; don't make active
-    (["subdir/image.fits"], {"make_active": False},
-     ["subdir/image.fits", "", True, False, AE.AMPLITUDE], {"make_active": False, "update_directory": False}),
-])
-def test_append_image(mocker, session, args, kwargs, expected_args, expected_kwargs):
-    mock_image_new = mocker.patch.object(Image, "new")
-    session.append_image(*args, **kwargs)
-    mock_image_new.assert_called_with(session, *expected_args, **expected_kwargs)
 
 # OVERLAY
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -115,16 +115,16 @@ def test_cd(session, mock_method, mock_call_action):
 @pytest.mark.parametrize("args,kwargs,expected_args,expected_kwargs", [
     # Open plain image
     (["subdir/image.fits"], {},
-     ["subdir/image.fits", "", False, False, CE.AMPLITUDE], {"update_directory": False}),
+     ["subdir", "image.fits", "", False, False], {"update_directory": False}),
+    # Append plain image
+    (["subdir/image.fits"], {"append": True},
+     ["subdir", "image.fits", "", True, False], {"update_directory": False}),
     # Open plain image; select different HDU
     (["subdir/image.fits"], {"hdu": "3"},
-     ["subdir/image.fits", "3", False, False, CE.AMPLITUDE], {"update_directory": False}),
-    # Open complex image
-    (["subdir/image.fits"], {"complex": True},
-     ["subdir/image.fits", "", False, True, CE.AMPLITUDE], {"update_directory": False}),
+     ["subdir", "image.fits", "3", False, False], {"update_directory": False}),
     # Open plain image; update file browser directory
     (["subdir/image.fits"], {"update_directory": True},
-     ["subdir/image.fits", "", False, False, CE.AMPLITUDE], {"update_directory": True}),
+     ["subdir", "image.fits", "", False, False], {"update_directory": True}),
 ])
 def test_open_image(mocker, session, args, kwargs, expected_args, expected_kwargs):
     mock_image_new = mocker.patch.object(Image, "new")
@@ -134,27 +134,15 @@ def test_open_image(mocker, session, args, kwargs, expected_args, expected_kwarg
 # TODO this should be merged with the test above when this separate function is removed
 
 
-@pytest.mark.parametrize("args,kwargs,expected_args,expected_kwargs", [
-    # Open plain image
-    (["subdir/image.fits"], {},
-     ["subdir/image.fits", "", True, False, CE.AMPLITUDE], {"make_active": True, "update_directory": False}),
-    # Open plain image; select different HDU
-    (["subdir/image.fits"], {"hdu": "3"},
-     ["subdir/image.fits", "3", True, False, CE.AMPLITUDE], {"make_active": True, "update_directory": False}),
-    # Open complex image
-    (["subdir/image.fits"], {"complex": True},
-     ["subdir/image.fits", "", True, True, CE.AMPLITUDE], {"make_active": True, "update_directory": False}),
-    # Open plain image; update file browser directory
-    (["subdir/image.fits"], {"update_directory": True},
-     ["subdir/image.fits", "", True, False, CE.AMPLITUDE], {"make_active": True, "update_directory": True}),
-    # Open plain image; don't make active
-    (["subdir/image.fits"], {"make_active": False},
-     ["subdir/image.fits", "", True, False, CE.AMPLITUDE], {"make_active": False, "update_directory": False}),
-])
-def test_append_image(mocker, session, args, kwargs, expected_args, expected_kwargs):
-    mock_image_new = mocker.patch.object(Image, "new")
-    session.append_image(*args, **kwargs)
-    mock_image_new.assert_called_with(session, *expected_args, **expected_kwargs)
+# @pytest.mark.parametrize("args,kwargs,expected_args,expected_kwargs", [
+#     # Open complex image
+#     (["subdir/image.fits"], {"expression": CE.AMPLITUDE},
+#      ["subdir", 'AMPLITUDE("image.fits")', "", False, True], {"update_directory": False})
+# ])
+# def test_open_complex_image(mocker, session, args, kwargs, expected_args, expected_kwargs):
+#     mock_image_new = mocker.patch.object(Image, "new")
+#     session.open_image(*args, **kwargs)
+#     mock_image_new.assert_called_with(session, *expected_args, **expected_kwargs)
 
 # OVERLAY
 


### PR DESCRIPTION
The PR is to resolve #91.

A function called `load_LEL_image` is added to `session.py` to fulfill the issue.

User need to provide the **_directory_** (instead of _path_, will explain later) of the image(s) being opened and the LEL **_expression_** to call `Image.new`.

In `Image.new`, the `expression` that was used for **complex-valued image** is now sharing its usage with **LEL arithmetic expression**. Since user only provide `directory` in `load_LEL_image`, hence the `file_name` must be an **_empty string_** after the processes of `resolve_file_path` and `posixpath.split`. Thus I am able to add a condition:
```
elif complex is False and file_name == "":
    image_arithmetic = True
    file_name = expression
```
to apply the LEL arithmetic expression. (A little bit tricky, but it does work...)

Furthermore, I renamed the `ArithmeticExpression` to `ComplexExpression` in `constants.py` to better clarify the difference between the **_LEL arithmetic expression_** and the **_complex expression_**.

Check for the result:
https://drive.google.com/file/d/1t0CRUDrSCBDWHPWTalCEp9PHlZAIQfe8/view?usp=sharing

@confluence, @kswang1029:  Please feel free to let me know if you have a better idea.