### PR TITLE
Icchen/81 high resolution export

### DIFF
--- a/carta/session.py
+++ b/carta/session.py
@@ -799,8 +799,8 @@ class Session:
 
     # SAVE IMAGE
 
-    @validate(NoneOr(Color()))
-    def rendered_view_url(self, background_color=None):
+    @validate(NoneOr(Color()), Number())
+    def rendered_view_url(self, background_color=None, image_ratio=1):
         """Get a data URL of the rendered active image.
 
         Parameters
@@ -814,14 +814,19 @@ class Session:
             A data URL for the rendered image in PNG format, base64-encoded.
 
         """
+        self.call_action("setIsExportingImage", True)
+        self.call_action("setImageRatio", image_ratio)
         self.call_action("waitForImageData")
         args = ["getImageDataUrl"]
         if background_color:
             args.append(background_color)
-        return self.call_action(*args, response_expected=True)
+        image_data_url = self.call_action(*args, response_expected=True)
+        self.call_action("setIsExportingImage", False)
+        self.call_action("resetImageRatio")
+        return image_data_url
 
-    @validate(NoneOr(Color()))
-    def rendered_view_data(self, background_color=None):
+    @validate(NoneOr(Color()), Number())
+    def rendered_view_data(self, background_color=None, image_ratio=1):
         """Get the decoded data of the rendered active image.
 
         Parameters
@@ -835,12 +840,12 @@ class Session:
             The decoded PNG image data.
 
         """
-        uri = self.rendered_view_url(background_color)
+        uri = self.rendered_view_url(background_color, image_ratio)
         data = uri.split(",")[1]
         return base64.b64decode(data)
 
-    @validate(String(), NoneOr(Color()))
-    def save_rendered_view(self, file_name, background_color=None):
+    @validate(String(), NoneOr(Color()), Number())
+    def save_rendered_view(self, file_name, background_color=None, image_ratio=1):
         """Save the decoded data of the rendered active image to a file.
 
         Parameters
@@ -851,7 +856,7 @@ class Session:
             The background color. By default the background will be transparent.
         """
         with open(file_name, 'wb') as f:
-            f.write(self.rendered_view_data(background_color))
+            f.write(self.rendered_view_data(background_color, image_ratio))
 
     def close(self):
         """Close any browser sessions and backend processes controlled by this session object.

--- a/carta/session.py
+++ b/carta/session.py
@@ -807,6 +807,8 @@ class Session:
         ----------
         background_color : {0}
             The background color. By default the background will be transparent.
+        image_ratio : {1}
+            The desired image ratio to output. Default is 1.
 
         Returns
         -------
@@ -822,7 +824,6 @@ class Session:
             args.append(background_color)
         image_data_url = self.call_action(*args, response_expected=True)
         self.call_action("setIsExportingImage", False)
-        self.call_action("resetImageRatio")
         return image_data_url
 
     @validate(NoneOr(Color()), Number())
@@ -833,6 +834,8 @@ class Session:
         ----------
         background_color : {0}
             The background color. By default the background will be transparent.
+        image_ratio : {1}
+            The desired image ratio to output. Default is 1.
 
         Returns
         -------
@@ -854,9 +857,13 @@ class Session:
             The name of the file.
         background_color : {1}
             The background color. By default the background will be transparent.
+        image_ratio : {2}
+            The desired image ratio to output. Default is 1.
         """
+        self.call_action("resetImageRatio")
         with open(file_name, 'wb') as f:
             f.write(self.rendered_view_data(background_color, image_ratio))
+        self.call_action("resetImageRatio")
 
     def close(self):
         """Close any browser sessions and backend processes controlled by this session object.

--- a/carta/session.py
+++ b/carta/session.py
@@ -799,8 +799,8 @@ class Session:
 
     # SAVE IMAGE
 
-    @validate(NoneOr(Color()))
-    def rendered_view_url(self, background_color=None):
+    @validate(NoneOr(Color()), Number())
+    def rendered_view_url(self, background_color=None, image_ratio=1):
         """Get a data URL of the rendered active image.
 
         Parameters
@@ -814,14 +814,19 @@ class Session:
             A data URL for the rendered image in PNG format, base64-encoded.
 
         """
+        self.call_action("setIsExportingImage", True)
+        self.call_action("setImageRatio", image_ratio)
         self.call_action("waitForImageData")
         args = ["getImageDataUrl"]
         if background_color:
             args.append(background_color)
-        return self.call_action(*args, response_expected=True)
+        image_data_url = self.call_action(*args, response_expected=True)
+        self.call_action("setIsExportingImage", False)
+        self.call_action("resetImageRatio")
+        return image_data_url
 
-    @validate(NoneOr(Color()))
-    def rendered_view_data(self, background_color=None):
+    @validate(NoneOr(Color()), Number())
+    def rendered_view_data(self, background_color=None, image_ratio=1):
         """Get the decoded data of the rendered active image.
 
         Parameters
@@ -835,7 +840,7 @@ class Session:
             The decoded PNG image data.
 
         """
-        uri = self.rendered_view_url(background_color)
+        uri = self.rendered_view_url(background_color, image_ratio)
         data = uri.split(",")[1]
         return base64.b64decode(data)
 
@@ -849,15 +854,9 @@ class Session:
             The name of the file.
         background_color : {1}
             The background color. By default the background will be transparent.
-        image_ratio : {2}
-            The desired image ratio to output. Default is 1.
         """
-        self.call_action("setIsExportingImage", True)
-        self.call_action("setImageRatio", image_ratio)
         with open(file_name, 'wb') as f:
-            f.write(self.rendered_view_data(background_color))
-        self.call_action("setIsExportingImage", False)
-        self.call_action("resetImageRatio")
+            f.write(self.rendered_view_data(background_color, image_ratio))
 
     def close(self):
         """Close any browser sessions and backend processes controlled by this session object.

--- a/carta/session.py
+++ b/carta/session.py
@@ -799,8 +799,8 @@ class Session:
 
     # SAVE IMAGE
 
-    @validate(NoneOr(Color()), Number())
-    def rendered_view_url(self, background_color=None, image_ratio=1):
+    @validate(NoneOr(Color()))
+    def rendered_view_url(self, background_color=None):
         """Get a data URL of the rendered active image.
 
         Parameters
@@ -814,19 +814,14 @@ class Session:
             A data URL for the rendered image in PNG format, base64-encoded.
 
         """
-        self.call_action("setIsExportingImage", True)
-        self.call_action("setImageRatio", image_ratio)
         self.call_action("waitForImageData")
         args = ["getImageDataUrl"]
         if background_color:
             args.append(background_color)
-        image_data_url = self.call_action(*args, response_expected=True)
-        self.call_action("setIsExportingImage", False)
-        self.call_action("resetImageRatio")
-        return image_data_url
+        return self.call_action(*args, response_expected=True)
 
-    @validate(NoneOr(Color()), Number())
-    def rendered_view_data(self, background_color=None, image_ratio=1):
+    @validate(NoneOr(Color()))
+    def rendered_view_data(self, background_color=None):
         """Get the decoded data of the rendered active image.
 
         Parameters
@@ -840,7 +835,7 @@ class Session:
             The decoded PNG image data.
 
         """
-        uri = self.rendered_view_url(background_color, image_ratio)
+        uri = self.rendered_view_url(background_color)
         data = uri.split(",")[1]
         return base64.b64decode(data)
 
@@ -854,9 +849,15 @@ class Session:
             The name of the file.
         background_color : {1}
             The background color. By default the background will be transparent.
+        image_ratio : {2}
+            The desired image ratio to output. Default is 1.
         """
+        self.call_action("setIsExportingImage", True)
+        self.call_action("setImageRatio", image_ratio)
         with open(file_name, 'wb') as f:
-            f.write(self.rendered_view_data(background_color, image_ratio))
+            f.write(self.rendered_view_data(background_color))
+        self.call_action("setIsExportingImage", False)
+        self.call_action("resetImageRatio")
 
     def close(self):
         """Close any browser sessions and backend processes controlled by this session object.

--- a/carta/session.py
+++ b/carta/session.py
@@ -816,6 +816,7 @@ class Session:
             A data URL for the rendered image in PNG format, base64-encoded.
 
         """
+        self.call_action("resetImageRatio")
         self.call_action("setIsExportingImage", True)
         self.call_action("setImageRatio", image_ratio)
         self.call_action("waitForImageData")
@@ -824,6 +825,7 @@ class Session:
             args.append(background_color)
         image_data_url = self.call_action(*args, response_expected=True)
         self.call_action("setIsExportingImage", False)
+        self.call_action("resetImageRatio")
         return image_data_url
 
     @validate(NoneOr(Color()), Number())
@@ -860,10 +862,8 @@ class Session:
         image_ratio : {2}
             The desired image ratio to output. Default is 1.
         """
-        self.call_action("resetImageRatio")
         with open(file_name, 'wb') as f:
             f.write(self.rendered_view_data(background_color, image_ratio))
-        self.call_action("resetImageRatio")
 
     def close(self):
         """Close any browser sessions and backend processes controlled by this session object.


### PR DESCRIPTION
@confluence 
This draft PR is to resolve #81.

An argument `image_ratio` and several steps are added into `save_rendered_view` to output png-image with different image ratio:
Setting `setIsExportingImage` to `True` enables setting output image ratio by calling `setImageRatio`. After writing the data to the file, we set `setIsExportingImage` to `False` and reset the image ratio to `1` with `resetImageRatio`.

The new-configured function does work for a new opened session. With the script like:
```
session.save_rendered_view(file_name="/home/icchen/Pictures/test/test_4.png", image_ratio=4)
```
I am able to generate a reolution = 400% png image like:
![test_4](https://github.com/CARTAvis/carta-python/assets/106953609/4664055b-d5eb-40aa-8e4a-604c47499169)
Nevertheless, there's something really odd: after a period of time (say 20 - 30 mins) without touching anything, the exact same execution will then generate something like:
![test_4a](https://github.com/CARTAvis/carta-python/assets/106953609/9024ab95-744e-41ba-a71c-ac3d5c99271e)
The image is still with the same 400% resolution in size, but the output content seems to lock to 100% resolution.

I still have no idea what's the reason that causes the phenomena, but I will discuss with @YuHsuan-Hwang and see if there's any mechanism at frontend will causes that.