### PR TITLE
Icchen/78 colorbar customization

### DIFF
--- a/carta/constants.py
+++ b/carta/constants.py
@@ -160,6 +160,10 @@ class GridMode(str, Enum):
 
 class ColorbarPosition (str, Enum):
     """Colorbar position"""
-    Right = "right"
-    Top = "top"
-    Bottom = "bottom"
+    RIGHT = "right"
+    TOP = "top"
+    BOTTOM = "bottom"
+
+class ColorbarLabelRotation(IntEnum):
+    MINUS90 = -90
+    POSITIVE90 = 90

--- a/carta/constants.py
+++ b/carta/constants.py
@@ -164,6 +164,7 @@ class ColorbarPosition (str, Enum):
     TOP = "top"
     BOTTOM = "bottom"
 
+
 class ColorbarRotation(IntEnum):
     MINUS90 = -90
     POSITIVE90 = 90

--- a/carta/constants.py
+++ b/carta/constants.py
@@ -156,3 +156,10 @@ class GridMode(str, Enum):
     """Grid modes."""
     DYNAMIC = "dynamic"
     FIXED = "fixed"
+
+
+class ColorbarPosition (str, Enum):
+    """Colorbar position"""
+    Right = "right"
+    Top = "top"
+    Bottom = "bottom"

--- a/carta/constants.py
+++ b/carta/constants.py
@@ -164,6 +164,6 @@ class ColorbarPosition (str, Enum):
     TOP = "top"
     BOTTOM = "bottom"
 
-class ColorbarLabelRotation(IntEnum):
+class ColorbarRotation(IntEnum):
     MINUS90 = -90
     POSITIVE90 = 90

--- a/carta/constants.py
+++ b/carta/constants.py
@@ -168,3 +168,27 @@ class ColorbarPosition (str, Enum):
 class ColorbarRotation(IntEnum):
     MINUS90 = -90
     POSITIVE90 = 90
+
+
+class Font(IntEnum):
+    """Font"""
+    sans_serif = 0
+    italic_sans_serif = 1
+    bold_sans_serif = 2
+    bold_italic_sans_serif = 3
+    times = 4
+    italic_times = 5
+    bold_times = 6
+    bold_italic_times = 7
+    arial = 8
+    bold_arial = 9
+    italic_arial = 10
+    bold_italic_arial = 11
+    palatino = 12
+    italic_palatino = 13
+    bold_palatino = 14
+    bold_italic_palatino = 15
+    courier_new = 16
+    italic_courier_new = 17
+    bold_courier_new = 18
+    bold_italic_courier_new = 19

--- a/carta/session.py
+++ b/carta/session.py
@@ -9,7 +9,7 @@ Alternatively, the user can create a new session which runs in a headless browse
 import base64
 
 from .image import Image
-from .constants import CoordinateSystem, LabelType, BeamType, PaletteColor, Overlay, PanelMode, GridMode, ArithmeticExpression
+from .constants import CoordinateSystem, LabelType, BeamType, PaletteColor, Overlay, PanelMode, GridMode, ArithmeticExpression, ColorbarPosition
 from .backend import Backend
 from .protocol import Protocol
 from .util import logger, Macro, split_action_path, CartaBadID, CartaBadSession, CartaBadUrl
@@ -781,35 +781,44 @@ class Session:
 
     # COLORBAR
 
-    @validate(Boolean(), Boolean(), String(), Number(), Number(), Number(), Boolean(), Constant(PaletteColor))
-    def configure_colorbar(self, visible=None, interactive=None, position=None, width=None, offset=None, tick_density=None, custom_color=None, color=None):
+    @validate(Boolean(), Boolean(), Constant(ColorbarPosition), Number(), Number(), Number(), Boolean(), Constant(PaletteColor),
+              Boolean(), Number())
+    def configure_colorbar(self, visible=True, interactive=None, position=None, width=None, offset=None, tick_density=None, custom_color=None, color=None,
+                           label_visible=None, label_rotation=None):
         """Set colorbar visibility.
 
         Parameters
         ----------
         """
-        if visible is not None:
-            self.set_visible(component="colorbar", visible=visible)
-            if visible is True:
-                if interactive is not None:
-                    self.call_action("overlayStore.colorbar.setInteractive", interactive)
-                if position is not None:
-                    self.call_action("overlayStore.colorbar.setPosition", position)
-                if width is not None:
-                    self.set_width(width=width, component="colorbar")
-                if offset is not None:
-                    self.call_action("overlayStore.colorbar.setOffset", offset)
-                if tick_density is not None:
-                    self.call_action("overlayStore.colorbar.setTickDensity", tick_density)
-                if custom_color is not None:
-                    self.call_action("overlayStore.colorbar.setCustomColor", custom_color)
-                    if custom_color is True:
-                        if color is not None:
-                            self.set_color(color=color, component="colorbar")
-                    if custom_color is False:
-                        return
-            if visible is False:
-                return
+
+        self.set_visible(component="colorbar", visible=visible)
+        if visible is True:
+            if interactive is not None:
+                self.call_action("overlayStore.colorbar.setInteractive", interactive)
+            if position is not None:
+                self.call_action("overlayStore.colorbar.setPosition", position)
+            if width is not None:
+                self.set_width(width=width, component="colorbar")
+            if offset is not None:
+                self.call_action("overlayStore.colorbar.setOffset", offset)
+            if tick_density is not None:
+                self.call_action("overlayStore.colorbar.setTickDensity", tick_density)
+            if custom_color is not None:
+                self.call_action("overlayStore.colorbar.setCustomColor", custom_color)
+                if custom_color is True:
+                    if color is not None:
+                        self.set_color(color=color, component="colorbar")
+                if custom_color is False:
+                    return
+            if label_visible is not None:
+                self.call_action("overlayStore.colorbar.setLabelVisible", label_visible)
+                if label_visible is True:
+                    if label_rotation is not None:
+                        self.call_action("overlayStore.colorbar.setLabelRotation", label_rotation)
+                if label_visible is False:
+                    return
+        if visible is False:
+            return
 
     # PROFILES (TODO)
 

--- a/carta/session.py
+++ b/carta/session.py
@@ -9,7 +9,7 @@ Alternatively, the user can create a new session which runs in a headless browse
 import base64
 
 from .image import Image
-from .constants import CoordinateSystem, LabelType, BeamType, PaletteColor, Overlay, PanelMode, GridMode, ArithmeticExpression, ColorbarPosition, ColorbarLabelRotation
+from .constants import CoordinateSystem, LabelType, BeamType, PaletteColor, Overlay, PanelMode, GridMode, ArithmeticExpression, ColorbarPosition, ColorbarRotation
 from .backend import Backend
 from .protocol import Protocol
 from .util import logger, Macro, split_action_path, CartaBadID, CartaBadSession, CartaBadUrl
@@ -782,15 +782,16 @@ class Session:
     # COLORBAR
 
     @validate(Boolean(), Boolean(), Constant(ColorbarPosition), Number(), Number(), Number(), Boolean(), Constant(PaletteColor),
-              Boolean(), Constant(ColorbarLabelRotation), Number(), Number(), Boolean(), String(), Boolean(), Constant(PaletteColor),)
+              Boolean(), Constant(ColorbarRotation), Number(), Number(), Boolean(), String(), Boolean(), Constant(PaletteColor),
+              Boolean(), Constant(ColorbarRotation), Number(), Number(), Boolean(), Number(), Boolean(), Constant(PaletteColor),)
     def configure_colorbar(self, visible=True, interactive=None, position=None, width=None, offset=None, tick_density=None, custom_color=None, color=None,
-                           label_visible=None, label_rotation=None, label_font=None, label_font_size=None, label_custom_text=None, label_text=None, label_custom_color=None, label_color=None):
+                           label_visible=None, label_rotation=None, label_font=None, label_font_size=None, label_custom_text=None, label_text=None, label_custom_color=None, label_color=None,
+                           number_visible=None, number_rotation=None, number_font=None, number_font_size=None, number_custom_precision=None, number_precision=None, number_custom_color=None, number_color=None,):
         """Configure colorbar
 
         Parameters
         ----------
         """
-
         self.set_visible(component="colorbar", visible=visible)
         if visible is True:
             if interactive is not None:
@@ -834,6 +835,31 @@ class Session:
                         if label_custom_color is False:
                             return
                 if label_visible is False:
+                    return
+            if number_visible is not None:
+                self.call_action("overlayStore.colorbar.setNumberVisible", number_visible)
+                if number_visible is True:
+                    if number_rotation is not None:
+                        self.call_action("overlayStore.colorbar.setNumberRotation", number_rotation)
+                    if number_font is not None:
+                        self.call_action("overlayStore.colorbar.setNumberFont", number_font)
+                    if number_font_size is not None:
+                        self.call_action("overlayStore.colorbar.setNumberFontSize", number_font_size)
+                    if number_custom_precision is not None:
+                        self.call_action("overlayStore.colorbar.setNumberCustomPrecision", number_custom_precision)
+                        if number_custom_precision is True:
+                            if number_precision is not None:
+                                self.call_action("overlayStore.colorbar.setNumberPrecision", number_precision)
+                        if number_custom_precision is False:
+                            return
+                    if number_custom_color is not None:
+                        self.call_action("overlayStore.colorbar.setNumberCustomColor", number_custom_color)
+                        if number_custom_color is True:
+                            if number_color is not None:
+                                self.call_action("overlayStore.colorbar.setNumberColor", number_color)
+                        if number_custom_color is False:
+                            return
+                if number_visible is False:
                     return
         if visible is False:
             return

--- a/carta/session.py
+++ b/carta/session.py
@@ -9,7 +9,7 @@ Alternatively, the user can create a new session which runs in a headless browse
 import base64
 
 from .image import Image
-from .constants import CoordinateSystem, LabelType, BeamType, PaletteColor, Overlay, PanelMode, GridMode, ArithmeticExpression, ColorbarPosition, ColorbarRotation
+from .constants import CoordinateSystem, LabelType, BeamType, PaletteColor, Overlay, PanelMode, GridMode, ArithmeticExpression, ColorbarPosition, ColorbarRotation, Font
 from .backend import Backend
 from .protocol import Protocol
 from .util import logger, Macro, split_action_path, CartaBadID, CartaBadSession, CartaBadUrl
@@ -782,8 +782,8 @@ class Session:
     # COLORBAR
 
     @validate(Boolean(), NoneOr(Boolean()), NoneOr(Constant(ColorbarPosition)), NoneOr(Number()), NoneOr(Number()), NoneOr(Number()), NoneOr(Boolean()), NoneOr(Constant(PaletteColor)),
-              NoneOr(Boolean()), NoneOr(Constant(ColorbarRotation)), NoneOr(Number()), NoneOr(Number()), NoneOr(Boolean()), NoneOr(String()), NoneOr(Boolean()), NoneOr(Constant(PaletteColor)),
-              NoneOr(Boolean()), NoneOr(Constant(ColorbarRotation)), NoneOr(Number()), NoneOr(Number()), NoneOr(Boolean()), NoneOr(Number()), NoneOr(Boolean()), NoneOr(Constant(PaletteColor)),
+              NoneOr(Boolean()), NoneOr(Constant(ColorbarRotation)), NoneOr(Constant(Font)), NoneOr(Number()), NoneOr(Boolean()), NoneOr(String()), NoneOr(Boolean()), NoneOr(Constant(PaletteColor)),
+              NoneOr(Boolean()), NoneOr(Constant(ColorbarRotation)), NoneOr(Constant(Font)), NoneOr(Number()), NoneOr(Boolean()), NoneOr(Number()), NoneOr(Boolean()), NoneOr(Constant(PaletteColor)),
               NoneOr(Boolean()), NoneOr(Number()), NoneOr(Number()), NoneOr(Boolean()), NoneOr(Constant(PaletteColor)),
               NoneOr(Boolean()), NoneOr(Number()), NoneOr(Boolean()), NoneOr(Constant(PaletteColor)))
     def set_colorbar(self, visible=True, interactive=None, position=None, width=None, offset=None, tick_density=None, custom_color=None, color=None,
@@ -816,52 +816,52 @@ class Session:
         label_visible : {8}
             Enable colorbar label. Initially set to disabled.
         label_rotation : {9}
-            The rotation of the label. Set to :obj:`carta.constants.ColorBarRotation.MINUS90` by default. Only can be configured when **label_visible** is enabled.
+            The rotation of the label. Set to :obj:`carta.constants.ColorbarRotation.MINUS90` by default. Only can be configured when **label_visible** is enabled.
         label_font : {10}
-            The label font. Only can be configured when **label_visible** is enabled.
+            The label font. Set to :obj:`carta.constants.Font.sans_serif` by default. Only can be configured when **label_visible** is enabled.
         label_font_size : {11}
             The label font size. Set to `15` by default. Only can be configured when **label_visible** is enabled.
         label_custom_text : {12}
             Enable custom label text. Initially set to disabled. Only can be configured when **label_visible** is enabled.
         label_text : {13}
             The label text. Only can be configured when **label_visible** and **label_custom_text** are enabled.
-        label_custom_color : {13}
+        label_custom_color : {14}
             Enable custom label color. Initially set to disabled. Only can be configured when **label_visible** is enabled.
-        label_color : {14}
+        label_color : {15}
             The label color. Set to :obj:`carta.constants.PaletteColor.BLUE` by default. Only can be configured when **label_visible** and **label_custom_color** are enabled.
-        number_visible : {15}
+        number_visible : {16}
             Enable colorbar number. Initially set to enabled.
-        number_rotation : {16}
-            The rotation of the number. Set to :obj:`carta.constants.ColorBarRotation.MINUS90` by default. Only can be configured when **number_visible** is enabled.
-        number_font : {17}
-            The number font. Only can be configured when **number_visible** is enabled.
-        number_font_size : {18}
+        number_rotation : {17}
+            The rotation of the number. Set to :obj:`carta.constants.ColorbarRotation.MINUS90` by default. Only can be configured when **number_visible** is enabled.
+        number_font : {18}
+            The number font. Set to :obj:`carta.constants.Font.sans_serif` by default. Only can be configured when **number_visible** is enabled.
+        number_font_size : {19}
             The number font size. Set to `12` by default. Only can be configured when **number_visible** is enabled.
-        number_custom_precision : {19}
+        number_custom_precision : {20}
             Enable custom number text. Initially set to disabled. Only can be configured when **label_visible** is enabled.
-        number_precision : {13}
+        number_precision : {21}
             The number text. Only can be configured when **number_visible** and **number_custom_text** are enabled.
-        number_custom_color : {20}
+        number_custom_color : {22}
             Enable custom number color. Initially set to disabled. Only can be configured when **number_visible** is enabled.
-        number_color : {21}
+        number_color : {23}
             The number color. Set to :obj:`carta.constants.PaletteColor.BLUE` by default. Only can be configured when **number_visible** and **number_custom_color** are enabled.
-        tick_visible : {22}
+        tick_visible : {24}
             Enable colorbar tick. Initially set to enabled.
-        tick_length : {23}
+        tick_length : {25}
             The tick length. Set to `6` by default. Only can be configured when **tick_visible** is enabled.
-        tick_width : {24}
+        tick_width : {26}
             The tick width. Set to `1` by default. Only can be configured when **tick_visible** is enabled.
-        tick_custom_color : {25}
+        tick_custom_color : {27}
             Enable custom tick color. Initially set to disabled. Only can be configured when **tick_visible** is enabled.
-        tick_color : {26}
+        tick_color : {28}
             The tick color. Set to :obj:`carta.constants.PaletteColor.BLUE` by default. Only can be configured when **tick_visible** and **tick_custom_color** are enabled.
-        border_visible : {27}
+        border_visible : {29}
             Enable colorbar border. Initially set to enabled.
-        border_width : {28}
+        border_width : {30}
             The border width. Set to `1` by default. Only can be configured when **border_visible** is enabled.
-        border_custom_color : {29}
+        border_custom_color : {31}
             Enable custom border color. Initially set to disabled. Only can be configured when **border_visible** is enabled.
-        border_color : {30}
+        border_color : {32}
             The border color. Set to :obj:`carta.constants.PaletteColor.BLUE` by default. Only can be configured when **border_visible** and **border_custom_color** are enabled.
         """
         self.set_visible(component="colorbar", visible=visible)

--- a/carta/session.py
+++ b/carta/session.py
@@ -9,7 +9,7 @@ Alternatively, the user can create a new session which runs in a headless browse
 import base64
 
 from .image import Image
-from .constants import CoordinateSystem, LabelType, BeamType, PaletteColor, Overlay, PanelMode, GridMode, ArithmeticExpression, ColorbarPosition
+from .constants import CoordinateSystem, LabelType, BeamType, PaletteColor, Overlay, PanelMode, GridMode, ArithmeticExpression, ColorbarPosition, ColorbarLabelRotation
 from .backend import Backend
 from .protocol import Protocol
 from .util import logger, Macro, split_action_path, CartaBadID, CartaBadSession, CartaBadUrl
@@ -782,10 +782,10 @@ class Session:
     # COLORBAR
 
     @validate(Boolean(), Boolean(), Constant(ColorbarPosition), Number(), Number(), Number(), Boolean(), Constant(PaletteColor),
-              Boolean(), Number())
+              Boolean(), Constant(ColorbarLabelRotation), Number(), Number(), Boolean(), String(), Boolean(), Constant(PaletteColor),)
     def configure_colorbar(self, visible=True, interactive=None, position=None, width=None, offset=None, tick_density=None, custom_color=None, color=None,
-                           label_visible=None, label_rotation=None):
-        """Set colorbar visibility.
+                           label_visible=None, label_rotation=None, label_font=None, label_font_size=None, label_custom_text=None, label_text=None, label_custom_color=None, label_color=None):
+        """Configure colorbar
 
         Parameters
         ----------
@@ -815,6 +815,24 @@ class Session:
                 if label_visible is True:
                     if label_rotation is not None:
                         self.call_action("overlayStore.colorbar.setLabelRotation", label_rotation)
+                    if label_font is not None:
+                        self.call_action("overlayStore.colorbar.setLabelFont", label_font)
+                    if label_font_size is not None:
+                        self.call_action("overlayStore.colorbar.setLabelFontSize", label_font_size)
+                    if label_custom_text is not None:
+                        self.call_action("overlayStore.colorbar.setLabelCustomText", label_custom_text)
+                        if label_custom_text is True:
+                            if label_text is not None:
+                                self.active_frame().call_action("setColorbarLabelCustomText", label_text)
+                        if label_custom_text is False:
+                            return
+                    if label_custom_color is not None:
+                        self.call_action("overlayStore.colorbar.setLabelCustomColor", label_custom_color)
+                        if label_custom_color is True:
+                            if label_color is not None:
+                                self.call_action("overlayStore.colorbar.setLabelColor", label_color)
+                        if label_custom_color is False:
+                            return
                 if label_visible is False:
                     return
         if visible is False:

--- a/carta/session.py
+++ b/carta/session.py
@@ -779,6 +779,11 @@ class Session:
         """Toggle the overlay labels."""
         self.call_action("overlayStore.toggleLabels")
 
+
+    # COLORBAR
+    def colorbar_visibility(self, visible, interaction, position, width, offset, ticks_density, enable_color, color):
+        self.set_visible("colorbar", visible)
+
     # PROFILES (TODO)
 
     @validate(Number(), Number())

--- a/carta/session.py
+++ b/carta/session.py
@@ -779,10 +779,37 @@ class Session:
         """Toggle the overlay labels."""
         self.call_action("overlayStore.toggleLabels")
 
-
     # COLORBAR
-    def colorbar_visibility(self, visible, interaction, position, width, offset, ticks_density, enable_color, color):
-        self.set_visible("colorbar", visible)
+
+    @validate(Boolean(), Boolean(), String(), Number(), Number(), Number(), Boolean(), Constant(PaletteColor))
+    def configure_colorbar(self, visible=None, interactive=None, position=None, width=None, offset=None, tick_density=None, custom_color=None, color=None):
+        """Set colorbar visibility.
+
+        Parameters
+        ----------
+        """
+        if visible is not None:
+            self.set_visible(component="colorbar", visible=visible)
+            if visible is True:
+                if interactive is not None:
+                    self.call_action("overlayStore.colorbar.setInteractive", interactive)
+                if position is not None:
+                    self.call_action("overlayStore.colorbar.setPosition", position)
+                if width is not None:
+                    self.set_width(width=width, component="colorbar")
+                if offset is not None:
+                    self.call_action("overlayStore.colorbar.setOffset", offset)
+                if tick_density is not None:
+                    self.call_action("overlayStore.colorbar.setTickDensity", tick_density)
+                if custom_color is not None:
+                    self.call_action("overlayStore.colorbar.setCustomColor", custom_color)
+                    if custom_color is True:
+                        if color is not None:
+                            self.set_color(color=color, component="colorbar")
+                    if custom_color is False:
+                        return
+            if visible is False:
+                return
 
     # PROFILES (TODO)
 

--- a/carta/session.py
+++ b/carta/session.py
@@ -786,7 +786,7 @@ class Session:
               NoneOr(Boolean()), NoneOr(Constant(ColorbarRotation)), NoneOr(Number()), NoneOr(Number()), NoneOr(Boolean()), NoneOr(Number()), NoneOr(Boolean()), NoneOr(Constant(PaletteColor)),
               NoneOr(Boolean()), NoneOr(Number()), NoneOr(Number()), NoneOr(Boolean()), NoneOr(Constant(PaletteColor)),
               NoneOr(Boolean()), NoneOr(Number()), NoneOr(Boolean()), NoneOr(Constant(PaletteColor)))
-    def configure_colorbar(self, visible=True, interactive=None, position=None, width=None, offset=None, tick_density=None, custom_color=None, color=None,
+    def set_colorbar(self, visible=True, interactive=None, position=None, width=None, offset=None, tick_density=None, custom_color=None, color=None,
                            label_visible=None, label_rotation=None, label_font=None, label_font_size=None, label_custom_text=None, label_text=None, label_custom_color=None, label_color=None,
                            number_visible=None, number_rotation=None, number_font=None, number_font_size=None, number_custom_precision=None, number_precision=None, number_custom_color=None, number_color=None,
                            tick_visible=None, tick_len=None, tick_width=None, tick_custom_color=None, tick_color=None,
@@ -795,6 +795,11 @@ class Session:
 
         Parameters
         ----------
+        visible : {0}
+            Enable colorbar. Initially set to enabled. If this is disabled, all the parameters of this function will not be configured.
+        interactive : {1}
+            Enable interactive colorbar. Initially set to enabled. If this is unset, the current status will be used.
+        position : {2}
         """
         self.set_visible(component="colorbar", visible=visible)
         if visible is True:

--- a/carta/session.py
+++ b/carta/session.py
@@ -781,12 +781,16 @@ class Session:
 
     # COLORBAR
 
-    @validate(Boolean(), Boolean(), Constant(ColorbarPosition), Number(), Number(), Number(), Boolean(), Constant(PaletteColor),
-              Boolean(), Constant(ColorbarRotation), Number(), Number(), Boolean(), String(), Boolean(), Constant(PaletteColor),
-              Boolean(), Constant(ColorbarRotation), Number(), Number(), Boolean(), Number(), Boolean(), Constant(PaletteColor),)
+    @validate(Boolean(), NoneOr(Boolean()), NoneOr(Constant(ColorbarPosition)), NoneOr(Number()), NoneOr(Number()), NoneOr(Number()), NoneOr(Boolean()), NoneOr(Constant(PaletteColor)),
+              NoneOr(Boolean()), NoneOr(Constant(ColorbarRotation)), NoneOr(Number()), NoneOr(Number()), NoneOr(Boolean()), NoneOr(String()), NoneOr(Boolean()), NoneOr(Constant(PaletteColor)),
+              NoneOr(Boolean()), NoneOr(Constant(ColorbarRotation)), NoneOr(Number()), NoneOr(Number()), NoneOr(Boolean()), NoneOr(Number()), NoneOr(Boolean()), NoneOr(Constant(PaletteColor)),
+              NoneOr(Boolean()), NoneOr(Number()), NoneOr(Number()), NoneOr(Boolean()), NoneOr(Constant(PaletteColor)),
+              NoneOr(Boolean()), NoneOr(Number()), NoneOr(Boolean()), NoneOr(Constant(PaletteColor)))
     def configure_colorbar(self, visible=True, interactive=None, position=None, width=None, offset=None, tick_density=None, custom_color=None, color=None,
                            label_visible=None, label_rotation=None, label_font=None, label_font_size=None, label_custom_text=None, label_text=None, label_custom_color=None, label_color=None,
-                           number_visible=None, number_rotation=None, number_font=None, number_font_size=None, number_custom_precision=None, number_precision=None, number_custom_color=None, number_color=None,):
+                           number_visible=None, number_rotation=None, number_font=None, number_font_size=None, number_custom_precision=None, number_precision=None, number_custom_color=None, number_color=None,
+                           tick_visible=None, tick_len=None, tick_width=None, tick_custom_color=None, tick_color=None,
+                           border_visible=None, border_width=None, border_custom_color=None, border_color=None):
         """Configure colorbar
 
         Parameters
@@ -860,6 +864,36 @@ class Session:
                         if number_custom_color is False:
                             return
                 if number_visible is False:
+                    return
+            if tick_visible is not None:
+                self.call_action("overlayStore.colorbar.setTickVisible", tick_visible)
+                if tick_visible is True:
+                    if tick_len is not None:
+                        self.call_action("overlayStore.colorbar.setTickLen", tick_len)
+                    if tick_width is not None:
+                        self.call_action("overlayStore.colorbar.setTickWidth", tick_width)
+                    if tick_custom_color is not None:
+                        self.call_action("overlayStore.colorbar.setTickCustomColor", tick_custom_color)
+                        if tick_custom_color is True:
+                            if tick_color is not None:
+                                self.call_action("overlayStore.colorbar.setTickColor", tick_color)
+                        if tick_custom_color is False:
+                            return
+                if tick_visible is False:
+                    return
+            if border_visible is not None:
+                self.call_action("overlayStore.colorbar.setBorderVisible", border_visible)
+                if border_visible is True:
+                    if border_width is not None:
+                        self.call_action("overlayStore.colorbar.setBorderWidth", border_width)
+                    if border_custom_color is not None:
+                        self.call_action("overlayStore.colorbar.setBorderCustomColor", border_custom_color)
+                        if border_custom_color is True:
+                            if border_color is not None:
+                                self.call_action("overlayStore.colorbar.setBorderColor", border_color)
+                        if border_custom_color is False:
+                            return
+                if border_visible is False:
                     return
         if visible is False:
             return

--- a/carta/session.py
+++ b/carta/session.py
@@ -787,19 +787,82 @@ class Session:
               NoneOr(Boolean()), NoneOr(Number()), NoneOr(Number()), NoneOr(Boolean()), NoneOr(Constant(PaletteColor)),
               NoneOr(Boolean()), NoneOr(Number()), NoneOr(Boolean()), NoneOr(Constant(PaletteColor)))
     def set_colorbar(self, visible=True, interactive=None, position=None, width=None, offset=None, tick_density=None, custom_color=None, color=None,
-                           label_visible=None, label_rotation=None, label_font=None, label_font_size=None, label_custom_text=None, label_text=None, label_custom_color=None, label_color=None,
-                           number_visible=None, number_rotation=None, number_font=None, number_font_size=None, number_custom_precision=None, number_precision=None, number_custom_color=None, number_color=None,
-                           tick_visible=None, tick_len=None, tick_width=None, tick_custom_color=None, tick_color=None,
-                           border_visible=None, border_width=None, border_custom_color=None, border_color=None):
+                     label_visible=None, label_rotation=None, label_font=None, label_font_size=None, label_custom_text=None, label_text=None, label_custom_color=None, label_color=None,
+                     number_visible=None, number_rotation=None, number_font=None, number_font_size=None, number_custom_precision=None, number_precision=None, number_custom_color=None, number_color=None,
+                     tick_visible=None, tick_len=None, tick_width=None, tick_custom_color=None, tick_color=None,
+                     border_visible=None, border_width=None, border_custom_color=None, border_color=None):
         """Configure colorbar
+
+        TODO: To get the font name and create an Enum for it.
 
         Parameters
         ----------
         visible : {0}
             Enable colorbar. Initially set to enabled. If this is disabled, all the parameters of this function will not be configured.
         interactive : {1}
-            Enable interactive colorbar. Initially set to enabled. If this is unset, the current status will be used.
+            Enable interactive colorbar. Initially set to enabled. If this is unset, the current configuration will be used.
         position : {2}
+            The colorbar position. The default is :obj:`carta.constants.ColorbarPosition.RIGHT`. If this is unset, the current configured position will be used.
+        width : {3}
+            The colorbar width in pixel. Set to `15` by default. If this is unset, the current configured width will be used.
+        offset : {4}
+            The offset between colorbar and the opened image in pixel. Set to `5` by default. If this is unset, the current configured offset will be used.
+        tick_density : {5}
+            The tick density of the colorbar (per 100 pixel). Set to `1` by default. If this is unset, the current configured density will be used.
+        custom_color : {6}
+            Enable custom color for the colorbar. Initially set to disabled.
+        color : {7}
+            The colorbar color. Set to :obj:`carta.constants.PaletteColor.BLUE` by default. Only can be configured when **custom_color** is enabled.
+        label_visible : {8}
+            Enable colorbar label. Initially set to disabled.
+        label_rotation : {9}
+            The rotation of the label. Set to :obj:`carta.constants.ColorBarRotation.MINUS90` by default. Only can be configured when **label_visible** is enabled.
+        label_font : {10}
+            The label font. Only can be configured when **label_visible** is enabled.
+        label_font_size : {11}
+            The label font size. Set to `15` by default. Only can be configured when **label_visible** is enabled.
+        label_custom_text : {12}
+            Enable custom label text. Initially set to disabled. Only can be configured when **label_visible** is enabled.
+        label_text : {13}
+            The label text. Only can be configured when **label_visible** and **label_custom_text** are enabled.
+        label_custom_color : {13}
+            Enable custom label color. Initially set to disabled. Only can be configured when **label_visible** is enabled.
+        label_color : {14}
+            The label color. Set to :obj:`carta.constants.PaletteColor.BLUE` by default. Only can be configured when **label_visible** and **label_custom_color** are enabled.
+        number_visible : {15}
+            Enable colorbar number. Initially set to enabled.
+        number_rotation : {16}
+            The rotation of the number. Set to :obj:`carta.constants.ColorBarRotation.MINUS90` by default. Only can be configured when **number_visible** is enabled.
+        number_font : {17}
+            The number font. Only can be configured when **number_visible** is enabled.
+        number_font_size : {18}
+            The number font size. Set to `12` by default. Only can be configured when **number_visible** is enabled.
+        number_custom_precision : {19}
+            Enable custom number text. Initially set to disabled. Only can be configured when **label_visible** is enabled.
+        number_precision : {13}
+            The number text. Only can be configured when **number_visible** and **number_custom_text** are enabled.
+        number_custom_color : {20}
+            Enable custom number color. Initially set to disabled. Only can be configured when **number_visible** is enabled.
+        number_color : {21}
+            The number color. Set to :obj:`carta.constants.PaletteColor.BLUE` by default. Only can be configured when **number_visible** and **number_custom_color** are enabled.
+        tick_visible : {22}
+            Enable colorbar tick. Initially set to enabled.
+        tick_length : {23}
+            The tick length. Set to `6` by default. Only can be configured when **tick_visible** is enabled.
+        tick_width : {24}
+            The tick width. Set to `1` by default. Only can be configured when **tick_visible** is enabled.
+        tick_custom_color : {25}
+            Enable custom tick color. Initially set to disabled. Only can be configured when **tick_visible** is enabled.
+        tick_color : {26}
+            The tick color. Set to :obj:`carta.constants.PaletteColor.BLUE` by default. Only can be configured when **tick_visible** and **tick_custom_color** are enabled.
+        border_visible : {27}
+            Enable colorbar border. Initially set to enabled.
+        border_width : {28}
+            The border width. Set to `1` by default. Only can be configured when **border_visible** is enabled.
+        border_custom_color : {29}
+            Enable custom border color. Initially set to disabled. Only can be configured when **border_visible** is enabled.
+        border_color : {30}
+            The border color. Set to :obj:`carta.constants.PaletteColor.BLUE` by default. Only can be configured when **border_visible** and **border_custom_color** are enabled.
         """
         self.set_visible(component="colorbar", visible=visible)
         if visible is True:


### PR DESCRIPTION
This PR is to resolve #78.
A function called `set_colorbar` is added to customize the configuration of `colorbar`.  All the parameters are optional by setting them to `None`. The logic of enabling configuring the parameters are similar to the frontend GUI. Take `border` related parameters for example, all the parameters (including `border_width`, `border_cuntom_color` and `border_color`) can be configured only if `border_visible` is enabled.
There is still a **todo** for this function, that is to create an Enum for `font names` in `constants.py`. Except for that, this funcntion is mostly functional for configuring colorbar. Please let me know if you have any idea about it.