### PR TITLE
Remove obsolete reference to a submodule of protocol buffer files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,6 @@ carta-python
 
 This is a prototype of a scripting interface which uses a generic HTTP interface in the CARTA backend as a proxy to call actions on the CARTA frontend.
 
-The protocol buffer definitions and associated files are in a submodule which has to be loaded. Either clone the repository with `--recursive`, or load the submodule afterwards:
-
-    git submodule update --init
-
 This package is not yet published on PyPi, but can be installed from the local repository directory with `pip`. Ensure that you're using a Python 3 installation and its corresponding `pip`, either using a `virtualenv` or the appropriate system executable, which may be called `pip3`. Required dependencies (the `requests` library) should be installed automatically:
 
     pip install .

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -4,13 +4,13 @@ CARTA scripting quick start
 Installation
 ------------
 
-This package is not yet published on PyPi, but can be installed from a local checkout of the repository. The protocol buffer definitions and associated files are in a submodule.
+This package is not yet published on PyPi, but can be installed from a local checkout of the repository.
 
 Ensure that you're using a Python 3 installation and its corresponding ``pip``, either using a ``virtualenv`` or the appropriate system executable, which may be called ``pip3``.
 
 .. code-block:: shell
 
-    git clone --recursive https://github.com/CARTAvis/carta-python.git
+    git clone https://github.com/CARTAvis/carta-python.git
     cd carta-python
     pip install .
 


### PR DESCRIPTION
This submodule was removed during the move from gRPC to HTTP.