### PR TITLE
Remove custom wrapper pwd

### DIFF
--- a/carta/constants.py
+++ b/carta/constants.py
@@ -1,6 +1,6 @@
 """This module provides a collection of enums corresponding to various enumerated types and other literal lists of options defined in the frontend. The members of these enums should be used in place of literal strings and numbers to represent these values; for example: ``Colormap.VIRIDIS`` rather than ``"viridis"``. """
 
-from enum import Enum, IntEnum, auto
+from enum import Enum, IntEnum
 
 
 # TODO make sure the __str__ is right for all the string values

--- a/carta/image.py
+++ b/carta/image.py
@@ -42,7 +42,7 @@ class Image:
         self._frame = Macro("", self._base_path)
 
     @classmethod
-    def new(cls, session, path, hdu, append, complex, expression):
+    def new(cls, session, path, hdu, append, complex, expression, make_active=True, update_directory=False):
         """Open or append a new image in the session and return an image object associated with it.
 
         This method should not be used directly. It is wrapped by :obj:`carta.session.Session.open_image` and :obj:`carta.session.Session.append_image`.
@@ -61,21 +61,31 @@ class Image:
             Whether the image is complex.
         expression : a member of :obj:`carta.constants.ArithmeticExpression`
             Arithmetic expression to use if opening a complex-valued image.
+        make_active : boolean
+            Whether the image should be made active in the frontend. This only applies if an image is being appended. The default is ``True``.
+        update_directory : boolean
+            Whether the starting directory of the frontend file browser should be updated to the parent directory of the image. The default is ``False``.
 
         Returns
         -------
         :obj:`carta.image.Image`
             A new image object.
         """
-        path = session.resolve_file_path(path)
-        directory, file_name = posixpath.split(path)
+        directory, file_name = posixpath.split(path) # TODO remove
+        
         command = "appendFile" if append else "openFile"
         if complex:
             image_arithmetic = True
             file_name = f'{expression}("{file_name}")'
         else:
             image_arithmetic = False
-        image_id = session.call_action(command, directory, file_name, hdu, image_arithmetic, return_path="frameInfo.fileId")
+        
+        params = [directory, file_name, hdu, image_arithmetic]
+        if append:
+            params.append(make_active)
+        params.append(update_directory)
+        
+        image_id = session.call_action(command, *params, return_path="frameInfo.fileId")
         return cls(session, image_id, file_name)
 
     @classmethod

--- a/carta/image.py
+++ b/carta/image.py
@@ -60,7 +60,7 @@ class Image:
         complex : boolean
             Whether the image is complex.
         expression : a member of :obj:`carta.constants.ArithmeticExpression`
-            Arithmetic expression to use if opening a complex-valued image.
+            Arithmetic expression to use if opening a complex-valued image. Ignored if the image is not complex.
         make_active : boolean
             Whether the image should be made active in the frontend. This only applies if an image is being appended. The default is ``True``.
         update_directory : boolean
@@ -73,19 +73,19 @@ class Image:
         """
         path = session.resolve_file_path(path)
         directory, file_name = posixpath.split(path)
-        
+
         command = "appendFile" if append else "openFile"
         if complex:
             image_arithmetic = True
             file_name = f'{expression}("{file_name}")'
         else:
             image_arithmetic = False
-        
+
         params = [directory, file_name, hdu, image_arithmetic]
         if append:
             params.append(make_active)
         params.append(update_directory)
-        
+
         image_id = session.call_action(command, *params, return_path="frameInfo.fileId")
         return cls(session, image_id, file_name)
 

--- a/carta/image.py
+++ b/carta/image.py
@@ -71,7 +71,8 @@ class Image:
         :obj:`carta.image.Image`
             A new image object.
         """
-        directory, file_name = posixpath.split(path) # TODO remove
+        path = session.resolve_file_path(path)
+        directory, file_name = posixpath.split(path)
         
         command = "appendFile" if append else "openFile"
         if complex:

--- a/carta/session.py
+++ b/carta/session.py
@@ -220,7 +220,7 @@ class Session:
         return browser.new_session_with_backend(executable_path, remote_host, params, timeout, token, frontend_url_timeout)
 
     def __repr__(self):
-        return f"Session(session_id={self.session_id}, uri={self._protocol.frontend_url})"
+        return f"Session(session_id={self.session_id}, uri={self._protocol.frontend_url if self._protocol else None})"
 
     def call_action(self, path, *args, **kwargs):
         """Call an action on the frontend through the backend's scripting interface.
@@ -274,10 +274,10 @@ class Session:
         return self.call_action("fetchParameter", macro, response_expected=True)
 
     # FILE BROWSING
-    
+
     def resolve_file_path(self, path):
         """Convert a file path to an absolute path.
-        
+
         This function prepends the session's current directory to a relative path, and normalizes the path to remove redundant separators and references.
 
         Parameters
@@ -296,7 +296,7 @@ class Session:
 
     def pwd(self):
         """The current directory.
-        
+
         This is the frontend file browser's currently saved starting directory. Whenever an image file is opened with the frontend's file browser (which may happen if the wrapper is connected to an interactive session), this directory is changed to the file's parent directory. By default, this directory is not changed if an image is opened through the wrapper (which bypasses the file browser).
 
         Returns
@@ -307,7 +307,6 @@ class Session:
         self.call_action("fileBrowserStore.getFileList", Macro("fileBrowserStore", "startingDirectory"))
         directory = self.get_value("fileBrowserStore.fileList.directory")
         return f"/{directory}".rstrip("/")
-
 
     def ls(self):
         """The current directory listing.
@@ -328,7 +327,7 @@ class Session:
 
     def cd(self, path):
         """Change the current directory.
-        
+
         This function changes the frontend file browser's starting directory.
 
         Parameters
@@ -379,7 +378,7 @@ class Session:
         update_directory : {5}
             Whether the starting directory of the frontend file browser should be updated to the parent directory of the image. The default is ``False``.
         """
-        return Image.new(self, path, hdu, True, complex, expression, make_active, update_directory)
+        return Image.new(self, path, hdu, True, complex, expression, make_active=make_active, update_directory=update_directory)
 
     def image_list(self):
         """Return the list of currently open images.

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -19,7 +19,7 @@ The required Python library dependencies should be installed automatically. To c
 You need access either to a CARTA backend executable, on the local host or on a remote host which you can access through SSH, or to a CARTA controller instance (a multi-user system with web-based authentication). You must be able to access the frontend served by this CARTA instance. If you are using your own backend executable, you must start it with the ``--enable_scripting`` commandline parameter to enable the scripting interface.
 
 .. note::
-   This version of the wrapper requires at least the 3.0.0-beta.3 versions of the CARTA backend, frontend and (optionally) controller. Older versions of these components use an outdated API which is no longer supported.
+   This version of the wrapper requires at least the 4.0 release versions of the CARTA backend, frontend and (optionally) controller. Older versions of these components may not work correctly and are not supported.
 
 If you want to create browser sessions from the wrapper, you also need to make sure that your desired browser is installed, together with a corresponding web driver. At present only Chrome (or Chromium) can be used for headless sessions.
 

--- a/scripts/style_check.sh
+++ b/scripts/style_check.sh
@@ -2,4 +2,4 @@
 
 # Check for PEP8 code style violations, but ignore long lines and ambiguous variable names
 
-pycodestyle --ignore=E501,E741 carta/*.py tests/*.py
+flake8 --ignore=E501,E741 carta/*.py tests/*.py

--- a/scripts/style_fix.sh
+++ b/scripts/style_fix.sh
@@ -10,4 +10,4 @@ autopep8 --in-place --ignore E501 carta/*.py tests/*.py
 
 echo "Outstanding issues:"
 
-pycodestyle --ignore=E501,E741 carta/*.py tests/*.py
+flake8 --ignore=E501,E741 carta/*.py tests/*.py

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="carta",
-    version="1.1.8",
+    version="1.1.9",
     author="Adrianna Pińska",
     author_email="adrianna.pinska@gmail.com",
     description="CARTA scripting wrapper written in Python",

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -127,10 +127,10 @@ def test_new(session, mock_session_call_action, mock_session_method, args, kwarg
 
     mock_session_call_action.assert_called_with(*expected_params, return_path='frameInfo.fileId')
 
-    assert(type(image_object) == Image)
-    assert(image_object.session == session)
-    assert(image_object.image_id == 123)
-    assert(image_object.file_name == expected_params[2])
+    assert type(image_object) == Image
+    assert image_object.session == session
+    assert image_object.image_id == 123
+    assert image_object.file_name == expected_params[2]
 
 
 # SIMPLE PROPERTIES TODO to be completed.

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -2,8 +2,9 @@ import types
 import pytest
 
 from carta.session import Session
-from carta.util import CartaValidationFailed
-from carta.constants import CoordinateSystem, NumberFormat as NF
+from carta.image import Image
+from carta.util import CartaValidationFailed, Macro
+from carta.constants import CoordinateSystem, NumberFormat as NF, ArithmeticExpression as AE
 
 # FIXTURES
 
@@ -70,6 +71,92 @@ def test_session_classmethods_have_docstrings(member):
 
 
 # TODO fill in missing session tests
+
+# PATHS
+
+@pytest.mark.parametrize("path, expected_path", [
+    ("foo", "/current/dir/foo"),
+    ("/foo", "/foo"),
+    ("..", "/current"),
+    (".", "/current/dir"),
+    ("foo/..", "/current/dir"),
+    ("foo/../bar", "/current/dir/bar"),
+])
+def test_resolve_file_path(session, mock_method, path, expected_path):
+    mock_pwd = mock_method("pwd", ["/current/dir"])
+    assert(session.resolve_file_path(path) == expected_path)
+
+
+def test_pwd(session, mock_call_action, mock_get_value):
+    mock_get_value.side_effect = ["current/dir/"]
+    pwd = session.pwd()
+    mock_call_action.assert_called_with("fileBrowserStore.getFileList", Macro('fileBrowserStore', 'startingDirectory'))
+    mock_get_value.assert_called_with("fileBrowserStore.fileList.directory")
+    assert(pwd == "/current/dir")
+
+
+def test_ls(session, mock_method, mock_call_action, mock_get_value):
+    mock_pwd = mock_method("pwd", ["/current/dir"])
+    mock_get_value.side_effect = [{"files": [{"name": "foo.fits"}, {"name": "bar.fits"}], "subdirectories": [{"name": "baz"}]}]
+    ls = session.ls()
+    mock_call_action.assert_called_with("fileBrowserStore.getFileList", "/current/dir")
+    mock_get_value.assert_called_with("fileBrowserStore.fileList")
+    assert(ls == ["bar.fits", "baz/", "foo.fits"])
+
+
+def test_cd(session, mock_method, mock_call_action):
+    mock_resolve_file_path = mock_method("resolve_file_path", ["/resolved/file/path"])
+    session.cd("original/path")
+    mock_call_action.assert_called_with("fileBrowserStore.saveStartingDirectory", "/resolved/file/path")
+
+# OPENING IMAGES
+
+
+@pytest.mark.parametrize("args,kwargs,expected_args,expected_kwargs", [
+    # Open plain image
+    (["subdir/image.fits"], {},
+     ["subdir/image.fits", "", False, False, AE.AMPLITUDE], {"update_directory": False}),
+    # Open plain image; select different HDU
+    (["subdir/image.fits"], {"hdu": "3"},
+     ["subdir/image.fits", "3", False, False, AE.AMPLITUDE], {"update_directory": False}),
+    # Open complex image
+    (["subdir/image.fits"], {"complex": True},
+     ["subdir/image.fits", "", False, True, AE.AMPLITUDE], {"update_directory": False}),
+    # Open plain image; update file browser directory
+    (["subdir/image.fits"], {"update_directory": True},
+     ["subdir/image.fits", "", False, False, AE.AMPLITUDE], {"update_directory": True}),
+])
+def test_open_image(mocker, session, args, kwargs, expected_args, expected_kwargs):
+    mock_image_new = mocker.patch.object(Image, "new")
+    session.open_image(*args, **kwargs)
+    mock_image_new.assert_called_with(session, *expected_args, **expected_kwargs)
+
+# TODO this should be merged with the test above when this separate function is removed
+
+
+@pytest.mark.parametrize("args,kwargs,expected_args,expected_kwargs", [
+    # Open plain image
+    (["subdir/image.fits"], {},
+     ["subdir/image.fits", "", True, False, AE.AMPLITUDE], {"make_active": True, "update_directory": False}),
+    # Open plain image; select different HDU
+    (["subdir/image.fits"], {"hdu": "3"},
+     ["subdir/image.fits", "3", True, False, AE.AMPLITUDE], {"make_active": True, "update_directory": False}),
+    # Open complex image
+    (["subdir/image.fits"], {"complex": True},
+     ["subdir/image.fits", "", True, True, AE.AMPLITUDE], {"make_active": True, "update_directory": False}),
+    # Open plain image; update file browser directory
+    (["subdir/image.fits"], {"update_directory": True},
+     ["subdir/image.fits", "", True, False, AE.AMPLITUDE], {"make_active": True, "update_directory": True}),
+    # Open plain image; don't make active
+    (["subdir/image.fits"], {"make_active": False},
+     ["subdir/image.fits", "", True, False, AE.AMPLITUDE], {"make_active": False, "update_directory": False}),
+])
+def test_append_image(mocker, session, args, kwargs, expected_args, expected_kwargs):
+    mock_image_new = mocker.patch.object(Image, "new")
+    session.append_image(*args, **kwargs)
+    mock_image_new.assert_called_with(session, *expected_args, **expected_kwargs)
+
+# OVERLAY
 
 
 @pytest.mark.parametrize("system", CoordinateSystem)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -83,8 +83,8 @@ def test_session_classmethods_have_docstrings(member):
     ("foo/../bar", "/current/dir/bar"),
 ])
 def test_resolve_file_path(session, mock_method, path, expected_path):
-    mock_pwd = mock_method("pwd", ["/current/dir"])
-    assert(session.resolve_file_path(path) == expected_path)
+    mock_method("pwd", ["/current/dir"])
+    assert session.resolve_file_path(path) == expected_path
 
 
 def test_pwd(session, mock_call_action, mock_get_value):
@@ -92,20 +92,20 @@ def test_pwd(session, mock_call_action, mock_get_value):
     pwd = session.pwd()
     mock_call_action.assert_called_with("fileBrowserStore.getFileList", Macro('fileBrowserStore', 'startingDirectory'))
     mock_get_value.assert_called_with("fileBrowserStore.fileList.directory")
-    assert(pwd == "/current/dir")
+    assert pwd == "/current/dir"
 
 
 def test_ls(session, mock_method, mock_call_action, mock_get_value):
-    mock_pwd = mock_method("pwd", ["/current/dir"])
+    mock_method("pwd", ["/current/dir"])
     mock_get_value.side_effect = [{"files": [{"name": "foo.fits"}, {"name": "bar.fits"}], "subdirectories": [{"name": "baz"}]}]
     ls = session.ls()
     mock_call_action.assert_called_with("fileBrowserStore.getFileList", "/current/dir")
     mock_get_value.assert_called_with("fileBrowserStore.fileList")
-    assert(ls == ["bar.fits", "baz/", "foo.fits"])
+    assert ls == ["bar.fits", "baz/", "foo.fits"]
 
 
 def test_cd(session, mock_method, mock_call_action):
-    mock_resolve_file_path = mock_method("resolve_file_path", ["/resolved/file/path"])
+    mock_method("resolve_file_path", ["/resolved/file/path"])
     session.cd("original/path")
     mock_call_action.assert_called_with("fileBrowserStore.saveStartingDirectory", "/resolved/file/path")
 


### PR DESCRIPTION
Fixes #126. We no longer maintain a separate local pwd in the wrapper; we stay synchronised with the GUI file browser. This means that using `session.cd` updates the GUI browser's current dir, and vice versa. We still need the function for resolving file paths (for relative paths).

I have added a normalization step to e.g. turn "foo/bar/../../baz" into "baz", so that using e.g. `session.cd("..")` doesn't lead to increasingly convoluted paths, but this might interact weirdly with people's symbolically linked directories. I could take this out or make it optional, but I don't know how much of an issue it's likely to be.

I have also added unit tests for these functions.