### PR TITLE
Fixed some docstrings with mangled whitespace

### DIFF
--- a/carta/image.py
+++ b/carta/image.py
@@ -164,6 +164,7 @@ class Image:
     @cached
     def file_name(self):
         """The name of the image.
+
         Returns
         -------
         string

--- a/carta/metadata.py
+++ b/carta/metadata.py
@@ -3,14 +3,20 @@
 
 def parse_header(raw_header):
     """Parse raw image header entries from the frontend into a more user-friendly format.
+
     Entries with T or F string values are automatically converted to booleans.
+
     ``HISTORY``, ``COMMENT`` and blank keyword entries are aggregated into single entries with list values and with ``'HISTORY'``, ``'COMMENT'`` and ``''`` as keys, respectively. An entry in the history list which begins with ``'>'`` will be concatenated with the previous entry.
+
     Adjacent ``COMMENT`` entries are not concatenated automatically.
+
     Any other header entries with no values are given values of ``None``.
+
     Parameters
     ----------
     raw_header : dict
         The raw header entries received from the frontend.
+
     Returns
     -------
     dict of string to string, integer, float, boolean, ``None`` or list of strings

--- a/carta/validation.py
+++ b/carta/validation.py
@@ -541,10 +541,12 @@ class IterableOf(Parameter):
 
 class MapOf(IterableOf):
     """A dictionary of keys and values which must match the given descriptors.
+
     Parameters
     ----------
     value_param : :obj:`carta.validation.Parameter`
         The value parameter descriptor.
+
     Attributes
     ----------
     value_param : :obj:`carta.validation.Parameter`
@@ -557,6 +559,7 @@ class MapOf(IterableOf):
 
     def validate(self, value, parent):
         """Check if each element of the iterable can be validated with the given descriptor.
+
         See :obj:`carta.validation.Parameter.validate` for general information about this method.
         """
 
@@ -573,6 +576,7 @@ class MapOf(IterableOf):
     @property
     def description(self):
         """A human-readable description of this parameter descriptor.
+
         Returns
         -------
         string
@@ -875,10 +879,13 @@ def validate(*vargs):
 
 def all_optional(*vargs):
     """Wrapper to make all parameters in an iterable optional.
+
     For improved legibility in functions with many sequential optional parameters. Can also enable reuse of validation parameters in functions which call other functions.
+
     Parameters
     ----------
     *vargs : iterable of :obj:`carta.validation.Parameter` objects
+
     Returns
     -------
     iterable of :obj:`carta.validation.Parameter` objects


### PR DESCRIPTION
Followup to #132; these must have been mangled during the manual C&P from the GitHub diffs.