### PR TITLE
Refactor tests

### DIFF
--- a/.github/workflows/style-check.yml
+++ b/.github/workflows/style-check.yml
@@ -19,6 +19,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install flake8
+        python -m pip install flake8-docstrings
     - name: Check style with script (flake8)
       run: |
         ./scripts/style_check.sh

--- a/carta/__init__.py
+++ b/carta/__init__.py
@@ -1,0 +1,1 @@
+"""This package provides a high-level API for scripting the CARTA image viewer."""

--- a/carta/backend.py
+++ b/carta/backend.py
@@ -76,7 +76,7 @@ class Backend:
         ssh_cmd = ("ssh", "-tt", remote_host) if remote_host is not None else tuple()
         self.cmd = tuple(str(p) for p in (*ssh_cmd, executable_path, *params))
 
-    def update_output(self):
+    def _update_output(self):
         while True:
             line = self.proc.stdout.readline()
             if not line:
@@ -106,7 +106,7 @@ class Backend:
                 break
 
             # Check for new output
-            self.update_output()
+            self._update_output()
 
             if self.proc.poll() is not None:
                 return False
@@ -131,7 +131,7 @@ class Backend:
                     break
 
                 # Check for new output
-                self.update_output()
+                self._update_output()
 
                 if self.proc.poll() is not None:
                     return False

--- a/carta/browser.py
+++ b/carta/browser.py
@@ -143,6 +143,7 @@ class Browser:
         return self.new_session_from_url(backend.frontend_url, backend.token, backend=backend, timeout=timeout, debug_no_auth=backend.debug_no_auth)
 
     def exit(self, msg):
+        """Exit the browser with an error."""
         self.close()
         raise CartaBadSession(msg)
 

--- a/carta/constants.py
+++ b/carta/constants.py
@@ -7,6 +7,7 @@ try:
     from enum import StrEnum
 except ImportError:
     class StrEnum(str, Enum):
+        """Backwards-compatible base class for string enums."""
         pass
 
 

--- a/carta/image.py
+++ b/carta/image.py
@@ -98,6 +98,7 @@ class Image(BasePathMixin):
         return [cls(session, f["value"]) for f in image_list]
 
     def __repr__(self):
+        """A human-readable representation of this image object."""
         return f"{self.session.session_id}:{self.image_id}:{self.file_name}"
 
     # METADATA

--- a/carta/protocol.py
+++ b/carta/protocol.py
@@ -12,6 +12,7 @@ from .util import logger, CartaBadRequest, CartaRequestFailed, CartaActionFailed
 
 
 class AuthType:
+    """The type of authentication used to connect to the backend or controller."""
     BACKEND, CONTROLLER, NONE = 0, 1, 2
 
 

--- a/carta/session.py
+++ b/carta/session.py
@@ -58,6 +58,7 @@ class Session:
         self._pwd = None
 
     def __del__(self):
+        """Delete this session object."""
         self.close()
 
     @classmethod
@@ -220,6 +221,7 @@ class Session:
         return browser.new_session_with_backend(executable_path, remote_host, params, timeout, token, frontend_url_timeout)
 
     def __repr__(self):
+        """A human-readable representation of this session object."""
         return f"Session(session_id={self.session_id}, uri={self._protocol.frontend_url if self._protocol else None})"
 
     def call_action(self, path, *args, **kwargs):

--- a/carta/units.py
+++ b/carta/units.py
@@ -20,6 +20,7 @@ class AngularSize:
         self.value = value
 
     def __init_subclass__(cls, **kwargs):
+        """Automatically register subclasses corresponding to size units."""
         super().__init_subclass__(**kwargs)
         cls._update_unit_regex(cls.INPUT_UNITS)
 
@@ -91,6 +92,7 @@ class AngularSize:
         return cls(float(value))
 
     def __str__(self):
+        """The canonical string representation of this size."""
         if type(self) is AngularSize:
             raise NotImplementedError()
         value = self.value * self.FACTOR
@@ -245,6 +247,7 @@ class DegreesCoordinate(WorldCoordinate):
         self.degrees = degrees
 
     def __str__(self):
+        """The canonical string representation of this coordinate."""
         return f"{self.degrees:g}"
 
 
@@ -291,11 +294,13 @@ class SexagesimalCoordinate(WorldCoordinate):
         self.seconds = seconds
 
     def __str__(self):
+        """The canonical string representation of this coordinate."""
         fractional_seconds, whole_seconds = math.modf(self.seconds)
         fraction_string = f"{fractional_seconds:g}".lstrip("0") if fractional_seconds else ""
         return f"{self.hours_or_degrees:g}:{self.minutes:0>2.0f}:{whole_seconds:0>2.0f}{fraction_string}"
 
     def as_tuple(self):
+        """The tuple representation of this coordinate."""
         return self.hours_or_degrees, self.minutes, self.seconds
 
 

--- a/carta/util.py
+++ b/carta/util.py
@@ -83,9 +83,11 @@ class Macro:
         self.variable = variable
 
     def __repr__(self):
+        """A human-readable representation of this macro."""
         return f"Macro('{self.target}', '{self.variable}')"
 
     def __eq__(self, other):
+        """Check for equality by comparing representations."""
         return repr(self) == repr(other)
 
     def json(self):

--- a/carta/validation.py
+++ b/carta/validation.py
@@ -680,6 +680,10 @@ class Size(Union):
         """Helper validator class which uses :obj:`carta.util.AngularSize` to validate strings."""
 
         def validate(self, value, parent):
+            """Check if the value can be parsed as an angular size.
+
+            See :obj:`carta.validation.Parameter.validate` for general information about this method.
+            """
             super().validate(value, parent)
             if not AngularSize.valid(value):
                 raise ValueError(f"{value} is not an angular size.")
@@ -699,6 +703,10 @@ class Coordinate(Union):
         """Helper validator class which uses :obj:`carta.util.WorldCoordinate` to validate strings."""
 
         def validate(self, value, parent):
+            """Check if the value can be parsed as a world coordinate.
+
+            See :obj:`carta.validation.Parameter.validate` for general information about this method.
+            """
             super().validate(value, parent)
             if not WorldCoordinate.valid(value):
                 raise ValueError(f"{value} is not a world coordinate.")
@@ -749,6 +757,10 @@ class Evaluate(Parameter):
         self.kwargs = kwargs
 
     def validate(self, value, parent):
+        """Validate the value after constructing the parameter descriptor object.
+
+        See :obj:`carta.validation.Parameter.validate` for general information about this method.
+        """
         args = []
         for arg in self.args:
             if isinstance(arg, Attr):

--- a/scripts/style_check.sh
+++ b/scripts/style_check.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
 # Check for PEP8 code style violations, but ignore long lines and ambiguous variable names
+# Check only for missing docstrings, except for __init__
 
-flake8 --ignore=E501,E741 carta/*.py tests/*.py
+flake8 --ignore=E501,E741,D --extend-select D10 --extend-ignore D107 carta/*.py
+
+# Also ignore docstring warnings in unit tests
+
+flake8 --ignore=E501,E741,D tests/*.py

--- a/scripts/style_fix.sh
+++ b/scripts/style_fix.sh
@@ -6,8 +6,13 @@ echo "Fixing issues automatically..."
 
 autopep8 --in-place --ignore E501 carta/*.py tests/*.py
 
-# Check for PEP8 code style violations, but ignore long lines and ambiguous variable names
-
 echo "Outstanding issues:"
 
-flake8 --ignore=E501,E741 carta/*.py tests/*.py
+# Check for PEP8 code style violations, but ignore long lines and ambiguous variable names
+# Check only for missing docstrings, except for __init__
+
+flake8 --ignore=E501,E741,D --extend-select D10 --extend-ignore D107 carta/*.py
+
+# Also ignore docstring warnings in unit tests
+
+flake8 --ignore=E501,E741,D tests/*.py

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,48 @@
+# Shared fixtures
+
+import pytest
+
+from carta.session import Session
+from carta.image import Image
+
+
+@pytest.fixture
+def session():
+    return Session(0, None)
+
+
+@pytest.fixture
+def image(session):
+    return Image(session, 0)
+
+
+@pytest.fixture
+def mock_get_value(mocker):
+    def func(obj):
+        return mocker.patch.object(obj, "get_value")
+    return func
+
+
+@pytest.fixture
+def mock_call_action(mocker):
+    def func(obj):
+        return mocker.patch.object(obj, "call_action")
+    return func
+
+
+@pytest.fixture
+def mock_property(mocker):
+    def func_outer(class_path):
+        def func_inner(property_name, mock_value):
+            return mocker.patch(f"{class_path}.{property_name}", new_callable=mocker.PropertyMock, return_value=mock_value)
+        return func_inner
+    return func_outer
+
+
+@pytest.fixture
+def mock_method(mocker):
+    def func_outer(obj):
+        def func_inner(method_name, return_values):
+            return mocker.patch.object(obj, method_name, side_effect=return_values)
+        return func_inner
+    return func_outer

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,7 +1,5 @@
-import types
 import pytest
 
-from carta.session import Session
 from carta.image import Image
 from carta.util import CartaValidationFailed
 from carta.constants import NumberFormat as NF, SpatialAxis as SA
@@ -40,35 +38,6 @@ def session_method(session, mock_method):
 
 
 # TESTS
-
-# DOCSTRINGS
-
-
-def test_image_class_has_docstring():
-    assert Image.__doc__ is not None
-
-
-def find_members(*classes, member_type=types.FunctionType):
-    for clazz in classes:
-        for name in dir(clazz):
-            if not name.startswith('__') and isinstance(getattr(clazz, name), member_type):
-                yield getattr(clazz, name)
-
-
-@pytest.mark.parametrize("member", find_members(Image))
-def test_image_methods_have_docstrings(member):
-    assert member.__doc__ is not None
-
-
-@pytest.mark.parametrize("member", find_members(Image, member_type=types.MethodType))
-def test_image_classmethods_have_docstrings(member):
-    assert member.__doc__ is not None
-
-
-@pytest.mark.parametrize("member", [m.fget for m in find_members(Image, member_type=property)])
-def test_image_properties_have_docstrings(member):
-    assert member.__doc__ is not None
-
 
 # CREATING AN IMAGE
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -10,40 +10,18 @@ from carta.constants import CoordinateSystem, NumberFormat as NF, ComplexCompone
 
 
 @pytest.fixture
-def session():
-    """Return a session object.
-
-    The session's protocol is set to None, so any tests that use this must also mock the session's call_action and/or higher-level functions which call it.
-    """
-    return Session(0, None)
+def get_value(session, mock_get_value):
+    return mock_get_value(session)
 
 
 @pytest.fixture
-def mock_get_value(session, mocker):
-    """Return a mock for session's get_value."""
-    return mocker.patch.object(session, "get_value")
+def call_action(session, mock_call_action):
+    return mock_call_action(session)
 
 
 @pytest.fixture
-def mock_call_action(session, mocker):
-    """Return a mock for session's call_action."""
-    return mocker.patch.object(session, "call_action")
-
-
-@pytest.fixture
-def mock_property(mocker):
-    """Return a helper function to mock the value of a decorated session property using a simple syntax."""
-    def func(property_name, mock_value):
-        return mocker.patch(f"carta.session.Session.{property_name}", new_callable=mocker.PropertyMock, return_value=mock_value)
-    return func
-
-
-@pytest.fixture
-def mock_method(session, mocker):
-    """Return a helper function to mock the return value(s) of an session method using a simple syntax."""
-    def func(method_name, return_values):
-        return mocker.patch.object(session, method_name, side_effect=return_values)
-    return func
+def method(session, mock_method):
+    return mock_method(session)
 
 
 # TESTS
@@ -82,32 +60,32 @@ def test_session_classmethods_have_docstrings(member):
     ("foo/..", "/current/dir"),
     ("foo/../bar", "/current/dir/bar"),
 ])
-def test_resolve_file_path(session, mock_method, path, expected_path):
-    mock_method("pwd", ["/current/dir"])
+def test_resolve_file_path(session, method, path, expected_path):
+    method("pwd", ["/current/dir"])
     assert session.resolve_file_path(path) == expected_path
 
 
-def test_pwd(session, mock_call_action, mock_get_value):
-    mock_get_value.side_effect = ["current/dir/"]
+def test_pwd(session, call_action, get_value):
+    get_value.side_effect = ["current/dir/"]
     pwd = session.pwd()
-    mock_call_action.assert_called_with("fileBrowserStore.getFileList", Macro('fileBrowserStore', 'startingDirectory'))
-    mock_get_value.assert_called_with("fileBrowserStore.fileList.directory")
+    call_action.assert_called_with("fileBrowserStore.getFileList", Macro('fileBrowserStore', 'startingDirectory'))
+    get_value.assert_called_with("fileBrowserStore.fileList.directory")
     assert pwd == "/current/dir"
 
 
-def test_ls(session, mock_method, mock_call_action, mock_get_value):
-    mock_method("pwd", ["/current/dir"])
-    mock_get_value.side_effect = [{"files": [{"name": "foo.fits"}, {"name": "bar.fits"}], "subdirectories": [{"name": "baz"}]}]
+def test_ls(session, method, call_action, get_value):
+    method("pwd", ["/current/dir"])
+    get_value.side_effect = [{"files": [{"name": "foo.fits"}, {"name": "bar.fits"}], "subdirectories": [{"name": "baz"}]}]
     ls = session.ls()
-    mock_call_action.assert_called_with("fileBrowserStore.getFileList", "/current/dir")
-    mock_get_value.assert_called_with("fileBrowserStore.fileList")
+    call_action.assert_called_with("fileBrowserStore.getFileList", "/current/dir")
+    get_value.assert_called_with("fileBrowserStore.fileList")
     assert ls == ["bar.fits", "baz/", "foo.fits"]
 
 
-def test_cd(session, mock_method, mock_call_action):
-    mock_method("resolve_file_path", ["/resolved/file/path"])
+def test_cd(session, method, call_action):
+    method("resolve_file_path", ["/resolved/file/path"])
     session.cd("original/path")
-    mock_call_action.assert_called_with("fileBrowserStore.saveStartingDirectory", "/resolved/file/path")
+    call_action.assert_called_with("fileBrowserStore.saveStartingDirectory", "/resolved/file/path")
 
 # OPENING IMAGES
 
@@ -179,8 +157,8 @@ def test_open_LEL_image(mocker, session, args, kwargs, expected_args, expected_k
 
 
 @pytest.mark.parametrize("append", [True, False])
-def test_open_images(mocker, session, mock_method, append):
-    mock_open_image = mock_method("open_image", ["1", "2", "3"])
+def test_open_images(mocker, session, method, append):
+    mock_open_image = method("open_image", ["1", "2", "3"])
     images = session.open_images(["foo.fits", "bar.fits", "baz.fits"], append)
     mock_open_image.assert_has_calls([
         mocker.call("foo.fits", append=append),
@@ -202,14 +180,14 @@ def test_open_images(mocker, session, mock_method, append):
     (True, "appendConcatFile"),
     (False, "openConcatFile"),
 ])
-def test_open_hypercube_guess_polarization(mocker, session, mock_call_action, mock_method, paths, expected_args, append, expected_command):
-    mock_method("pwd", ["/current/dir"])
-    mock_method("resolve_file_path", ["/resolved/path"] * 3)
-    mock_call_action.side_effect = [*expected_args[0], 123]
+def test_open_hypercube_guess_polarization(mocker, session, call_action, method, paths, expected_args, append, expected_command):
+    method("pwd", ["/current/dir"])
+    method("resolve_file_path", ["/resolved/path"] * 3)
+    call_action.side_effect = [*expected_args[0], 123]
 
     hypercube = session.open_hypercube(paths, append)
 
-    mock_call_action.assert_has_calls([
+    call_action.assert_has_calls([
         mocker.call("fileBrowserStore.getStokesFile", "/resolved/path", "foo.fits", ""),
         mocker.call("fileBrowserStore.getStokesFile", "/resolved/path", "bar.fits", ""),
         mocker.call("fileBrowserStore.getStokesFile", "/resolved/path", "baz.fits", ""),
@@ -235,16 +213,16 @@ def test_open_hypercube_guess_polarization(mocker, session, mock_call_action, mo
         {"directory": "/resolved/path", "file": "bar.fits", "hdu": "", "polarizationType": 1},
     ], "Duplicate polarizations deduced"),
 ])
-def test_open_hypercube_guess_polarization_bad(mocker, session, mock_call_action, mock_method, paths, expected_calls, mocked_side_effect, expected_error):
-    mock_method("pwd", ["/current/dir"])
-    mock_method("resolve_file_path", ["/resolved/path"] * 3)
-    mock_call_action.side_effect = mocked_side_effect
+def test_open_hypercube_guess_polarization_bad(mocker, session, call_action, method, paths, expected_calls, mocked_side_effect, expected_error):
+    method("pwd", ["/current/dir"])
+    method("resolve_file_path", ["/resolved/path"] * 3)
+    call_action.side_effect = mocked_side_effect
 
     with pytest.raises(ValueError) as e:
         session.open_hypercube(paths)
     assert expected_error in str(e.value)
 
-    mock_call_action.assert_has_calls([mocker.call(*args) for args in expected_calls])
+    call_action.assert_has_calls([mocker.call(*args) for args in expected_calls])
 
 
 @pytest.mark.parametrize("paths,expected_args", [
@@ -259,14 +237,14 @@ def test_open_hypercube_guess_polarization_bad(mocker, session, mock_call_action
     (True, "appendConcatFile"),
     (False, "openConcatFile"),
 ])
-def test_open_hypercube_explicit_polarization(mocker, session, mock_call_action, mock_method, paths, expected_args, append, expected_command):
-    mock_method("pwd", ["/current/dir"])
-    mock_method("resolve_file_path", ["/resolved/path"] * 3)
-    mock_call_action.side_effect = [123]
+def test_open_hypercube_explicit_polarization(mocker, session, call_action, method, paths, expected_args, append, expected_command):
+    method("pwd", ["/current/dir"])
+    method("resolve_file_path", ["/resolved/path"] * 3)
+    call_action.side_effect = [123]
 
     hypercube = session.open_hypercube(paths, append)
 
-    mock_call_action.assert_has_calls([
+    call_action.assert_has_calls([
         mocker.call(expected_command, *expected_args),
     ])
 
@@ -280,9 +258,9 @@ def test_open_hypercube_explicit_polarization(mocker, session, mock_call_action,
     (["foo.fits"], "at least 2"),
 ])
 @pytest.mark.parametrize("append", [True, False])
-def test_open_hypercube_bad(mocker, session, mock_call_action, mock_method, paths, expected_error, append):
-    mock_method("pwd", ["/current/dir"])
-    mock_method("resolve_file_path", ["/resolved/path"] * 3)
+def test_open_hypercube_bad(mocker, session, call_action, method, paths, expected_error, append):
+    method("pwd", ["/current/dir"])
+    method("resolve_file_path", ["/resolved/path"] * 3)
 
     with pytest.raises(Exception) as e:
         session.open_hypercube(paths, append)
@@ -293,9 +271,9 @@ def test_open_hypercube_bad(mocker, session, mock_call_action, mock_method, path
 
 
 @pytest.mark.parametrize("system", CoordinateSystem)
-def test_set_coordinate_system(session, mock_call_action, system):
+def test_set_coordinate_system(session, call_action, system):
     session.set_coordinate_system(system)
-    mock_call_action.assert_called_with("overlayStore.global.setSystem", system)
+    call_action.assert_called_with("overlayStore.global.setSystem", system)
 
 
 def test_set_coordinate_system_invalid(session):
@@ -304,18 +282,18 @@ def test_set_coordinate_system_invalid(session):
     assert "Invalid function parameter" in str(e.value)
 
 
-def test_coordinate_system(session, mock_get_value):
-    mock_get_value.return_value = "AUTO"
+def test_coordinate_system(session, get_value):
+    get_value.return_value = "AUTO"
     system = session.coordinate_system()
-    mock_get_value.assert_called_with("overlayStore.global.system")
+    get_value.assert_called_with("overlayStore.global.system")
     assert isinstance(system, CoordinateSystem)
 
 
 @pytest.mark.parametrize("x", NF)
 @pytest.mark.parametrize("y", NF)
-def test_set_custom_number_format(mocker, session, mock_call_action, x, y):
+def test_set_custom_number_format(mocker, session, call_action, x, y):
     session.set_custom_number_format(x, y)
-    mock_call_action.assert_has_calls([
+    call_action.assert_has_calls([
         mocker.call("overlayStore.numbers.setFormatX", x),
         mocker.call("overlayStore.numbers.setFormatY", y),
         mocker.call("overlayStore.numbers.setCustomFormat", True),
@@ -333,15 +311,15 @@ def test_set_custom_number_format_invalid(session, x, y):
     assert "Invalid function parameter" in str(e.value)
 
 
-def test_clear_custom_number_format(session, mock_call_action):
+def test_clear_custom_number_format(session, call_action):
     session.clear_custom_number_format()
-    mock_call_action.assert_called_with("overlayStore.numbers.setCustomFormat", False)
+    call_action.assert_called_with("overlayStore.numbers.setCustomFormat", False)
 
 
-def test_number_format(session, mock_get_value, mocker):
-    mock_get_value.side_effect = [NF.DEGREES, NF.DEGREES, False]
+def test_number_format(session, get_value, mocker):
+    get_value.side_effect = [NF.DEGREES, NF.DEGREES, False]
     x, y, _ = session.number_format()
-    mock_get_value.assert_has_calls([
+    get_value.assert_has_calls([
         mocker.call("overlayStore.numbers.formatTypeX"),
         mocker.call("overlayStore.numbers.formatTypeY"),
         mocker.call("overlayStore.numbers.customFormat"),

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,7 +1,5 @@
-import types
 import pytest
 
-from carta.session import Session
 from carta.image import Image
 from carta.util import CartaValidationFailed, Macro
 from carta.constants import CoordinateSystem, NumberFormat as NF, ComplexComponent as CC, Polarization as Pol
@@ -25,28 +23,6 @@ def method(session, mock_method):
 
 
 # TESTS
-
-
-def test_session_class_has_docstring():
-    assert Session.__doc__ is not None
-
-
-def find_members(*classes, member_type=types.FunctionType):
-    for clazz in classes:
-        for name in dir(clazz):
-            if not name.startswith('__') and isinstance(getattr(clazz, name), member_type):
-                yield getattr(clazz, name)
-
-
-@pytest.mark.parametrize("member", find_members(Session))
-def test_session_methods_have_docstrings(member):
-    assert member.__doc__ is not None
-
-
-@pytest.mark.parametrize("member", find_members(Session, member_type=types.MethodType))
-def test_session_classmethods_have_docstrings(member):
-    assert member.__doc__ is not None
-
 
 # TODO fill in missing session tests
 

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,25 +1,7 @@
-import types
 import pytest
 
 from carta.units import AngularSize, DegreesSize, ArcminSize, ArcsecSize, MilliarcsecSize, MicroarcsecSize, WorldCoordinate, DegreesCoordinate, HMSCoordinate, DMSCoordinate
 from carta.constants import NumberFormat as NF, SpatialAxis as SA
-
-
-@pytest.mark.parametrize("clazz", [AngularSize, WorldCoordinate])
-def test_class_has_docstring(clazz):
-    assert clazz.__doc__ is not None
-
-
-def find_members(*classes, member_type=types.MethodType):
-    for clazz in classes:
-        for name in dir(clazz):
-            if not name.startswith('__') and isinstance(getattr(clazz, name), member_type):
-                yield getattr(clazz, name)
-
-
-@pytest.mark.parametrize("member", find_members(AngularSize, WorldCoordinate))
-def test_class_classmethods_have_docstrings(member):
-    assert member.__doc__ is not None
 
 
 @pytest.mark.parametrize("size,valid", [


### PR DESCRIPTION
This is a helper PR to 1) factor out the fixture refactoring from #123, and 2) remove the docstring checks from the unit test code and add docstring checks to the style check with a flake8 plugin. There are some minor changes to add missing docstrings and rename one method which shouldn't be public.