### PR TITLE
selenium find_element syntax upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This package is not yet published on PyPi, but can be installed from the local r
 
     pip install .
 
-To create a new frontend session which is controlled by the wrapper instead of connecting to an existing frontend session, you also need to install the `selenium` Python library. You also need to make sure that your desired browser is installed, together with a corresponding web driver.
+To create a new frontend session which is controlled by the wrapper instead of connecting to an existing frontend session, you also need to install the `selenium 4.3+` Python library. You also need to make sure that your desired browser is installed, together with a corresponding web driver.
 
 Some example usage of the client as a module is shown in the [documentation](https://carta-python.readthedocs.io).
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This package is not yet published on PyPi, but can be installed from the local r
 
     pip install .
 
-To create a new frontend session which is controlled by the wrapper instead of connecting to an existing frontend session, you also need to install the `selenium 4.3+` Python library. You also need to make sure that your desired browser is installed, together with a corresponding web driver.
+To create a new frontend session which is controlled by the wrapper instead of connecting to an existing frontend session, you also need to install the `selenium` Python library. You also need to make sure that your desired browser is installed, together with a corresponding web driver.
 
 Some example usage of the client as a module is shown in the [documentation](https://carta-python.readthedocs.io).
 

--- a/carta/browser.py
+++ b/carta/browser.py
@@ -4,6 +4,7 @@ import time
 
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.common.by import By
 from selenium.common.exceptions import NoSuchElementException
 
 from .backend import Backend
@@ -87,7 +88,7 @@ class Browser:
 
             try:
                 # We can't use .text because Selenium is too clever to return the text of invisible elements.
-                session_id = int(self.driver.find_element_by_id("info-session-id").get_attribute("textContent"))
+                session_id = int(self.driver.find_element(By.ID, "info-session-id").get_attribute("textContent"))
             except (NoSuchElementException, ValueError) as e:
                 last_error = str(e)
                 time.sleep(1)


### PR DESCRIPTION
Fix #144, upgraded selenium find_element syntax. ```find_element_by_id``` is no longer supported after version 4.3. The old function is replaced with ```find_element```.