### PR TITLE
Overlay settings store was renamed in the frontend.

### DIFF
--- a/carta/wcs_overlay.py
+++ b/carta/wcs_overlay.py
@@ -104,7 +104,7 @@ class SessionWCSOverlay(BasePathMixin):
         height : {1}
             The new height, in pixels, divided by the device pixel ratio.
         """
-        self.call_action("setViewDimension", width, height)
+        self.session.call_action("setImageViewDimensions", width, height)
 
 
 class OverlayComponent(BasePathMixin):

--- a/carta/wcs_overlay.py
+++ b/carta/wcs_overlay.py
@@ -44,7 +44,7 @@ class SessionWCSOverlay(BasePathMixin):
 
     def __init__(self, session):
         self.session = session
-        self._base_path = "overlayStore"
+        self._base_path = "overlaySettings"
 
         self._components = {}
         for component in Overlay:
@@ -126,7 +126,7 @@ class OverlayComponent(BasePathMixin):
         OverlayComponent.CLASS[cls.COMPONENT] = cls
 
     def __init__(self, overlay):
-        self._base_path = f"overlayStore.{self.COMPONENT}"
+        self._base_path = f"overlaySettings.{self.COMPONENT}"
         self.session = overlay.session
 
 

--- a/tests/test_wcs_overlay.py
+++ b/tests/test_wcs_overlay.py
@@ -26,6 +26,11 @@ def component_get_value(overlay, mocker):
 
 
 @pytest.fixture
+def session_call_action(session, mock_call_action):
+    return mock_call_action(session)
+
+
+@pytest.fixture
 def session_get_value(session, mock_get_value):
     return mock_get_value(session)
 
@@ -106,9 +111,9 @@ def test_palette_to_rgb(overlay, session_get_value, theme_is_dark, expected_rgb)
     assert rgb == expected_rgb
 
 
-def test_set_view_area(overlay, call_action):
+def test_set_view_area(overlay, session_call_action):
     overlay.set_view_area(100, 200)
-    call_action.assert_called_with("setViewDimension", 100, 200)
+    session_call_action.assert_called_with("setImageViewDimensions", 100, 200)
 
 
 # COMPONENT TESTS


### PR DESCRIPTION
@Jordatious hit this bug while trying to set the centre (which requires the overlay number formats):
```
File "/Users/jcollier/work/scripts/python/create-carta-regions.py", line 187, in overlay_ellipses
    img.set_center(center[0],center[1])
  File "/Users/jcollier/opt/anaconda3/envs/carta-python/lib/python3.12/site-packages/carta/validation.py", line 958, in newfunc
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jcollier/opt/anaconda3/envs/carta-python/lib/python3.12/site-packages/carta/image.py", line 395, in set_center
    number_format_x, number_format_y = self.session.wcs.numbers.format
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jcollier/opt/anaconda3/envs/carta-python/lib/python3.12/site-packages/carta/wcs_overlay.py", line 688, in format
    format_x = self.get_value("formatTypeX")
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jcollier/opt/anaconda3/envs/carta-python/lib/python3.12/site-packages/carta/util.py", line 191, in get_value
    return self.session.get_value(f"{self._base_path}.{path}", return_path=return_path)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jcollier/opt/anaconda3/envs/carta-python/lib/python3.12/site-packages/carta/session.py", line 293, in get_value
    return self.call_action("fetchParameter", macro, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jcollier/opt/anaconda3/envs/carta-python/lib/python3.12/site-packages/carta/session.py", line 267, in call_action
    return self._protocol.request_scripting_action(self.session_id, path, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jcollier/opt/anaconda3/envs/carta-python/lib/python3.12/site-packages/carta/protocol.py", line 335, in request_scripting_action
    raise CartaActionFailed(f"{carta_action_description} failed: {response_data.get('message', 'No error message received.')}")
carta.util.CartaActionFailed: CARTA scripting action .fetchParameter called with parameters (Macro('overlayStore.numbers', 'formatTypeX'),) failed: TypeError: Cannot read properties of undefined (reading 'numbers')
```

This affects recent versions, but 5.0.0-beta.1 works. I found that [this frontend commit](https://github.com/CARTAvis/carta-frontend/commit/6835d82cfe287fd213acc281b88e9113d8729409#diff-eacb148ce301632f752035ee2e9d3e7bddb2a2bcca67627871fb2c810e0f0272) renamed the `overlayStore` property to `overlaySettings`, which breaks the paths of all global WCS overlay actions. This PR updates the name.

@Jordatious does this fix your issue?